### PR TITLE
D-Pad Support and improved item behavior linked to new D-Pad

### DIFF
--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -5,6 +5,7 @@
 #include "ultra64.h"
 #include "z64dma.h"
 #include "z64view.h"
+#include "z64player.h"
 
 struct PlayState;
 
@@ -261,8 +262,8 @@ void Interface_SetSceneRestrictions(struct PlayState* play);
 void Inventory_SwapAgeEquipment(void);
 void Interface_InitHorsebackArchery(struct PlayState* play);
 void func_800849EC(struct PlayState* play);
-void Interface_LoadItemIcon1(struct PlayState* play, u8 button);
-void Interface_LoadItemIcon2(struct PlayState* play, u8 button);
+void Interface_LoadItemIcon1(struct PlayState* play, u16 button);
+void Interface_LoadItemIcon2(struct PlayState* play, u16 button);
 void Interface_LoadItemIconDpad(struct PlayState* play, u8 button);
 u8 Interface_GetArrowFromDpad(u8 button);
 u8 Interface_GetItemFromDpad(u8 button);
@@ -291,6 +292,8 @@ void Interface_Draw(struct PlayState* play);
 void Interface_Update(struct PlayState* play);
 void Interface_Destroy(struct PlayState* play);
 void Interface_Init(struct PlayState* play);
+void ItemIcons_Init(struct PlayState* play, struct Player* player);
+void Interface_ChangeDpadSet(struct PlayState* play);
 
 extern s16 gSpoilingItems[3];
 extern s16 gSpoilingItemReverts[3];

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -119,11 +119,11 @@ typedef struct InterfaceContext {
     /* 0x0240 */ u16    unk_240;
     /* 0x0242 */ u16    unk_242;
     /* 0x0224 */ u16    unk_244; // screen fill alpha?
-    /* 0x0246 */ u16    aAlpha; // also carrots alpha
-    /* 0x0248 */ u16    bAlpha; // also HBA score alpha
-    /* 0x024A */ u16    cLeftAlpha;
-    /* 0x024C */ u16    cDownAlpha;
-    /* 0x024E */ u16    cRightAlpha;
+    /* 0x0246 */ u8     aAlpha; // also carrots alpha
+    /* 0x0248 */ u8     bAlpha; // also HBA score alpha
+    /* 0x024A */ u8     cLeftAlpha;
+    /* 0x024C */ u8     cDownAlpha;
+    /* 0x024E */ u8     cRightAlpha;
     /* 0x0250 */ u16    healthAlpha; // also max C-Up alpha
     /* 0x0252 */ u16    magicAlpha; // also Rupee and Key counters alpha
     /* 0x0254 */ u16    minimapAlpha;
@@ -191,6 +191,17 @@ typedef struct InterfaceContext {
 #define C_UP_BUTTON_X 254 + (WIDESCREEN ? 104 : 0)
 #define C_UP_BUTTON_Y 16
 
+#define DPAD_X           (18     + 6)  // R_MAGIC_METER_X
+#define DPAD_Y           (42     + 30) // R_MAGIC_METER_Y_LOWER
+#define D_UP_BUTTON_X    (DPAD_X + 2)
+#define D_UP_BUTTON_Y    (DPAD_Y - 14)
+#define D_RIGHT_BUTTON_X (DPAD_X + 18)
+#define D_RIGHT_BUTTON_Y (DPAD_Y + 2)
+#define D_DOWN_BUTTON_X  (DPAD_X + 2)
+#define D_DOWN_BUTTON_Y  (DPAD_Y + 16)
+#define D_LEFT_BUTTON_X  (DPAD_X - 14)
+#define D_LEFT_BUTTON_Y  (DPAD_Y + 2)
+
 #if !PLATFORM_GC
 #define START_BUTTON_R 200
 #define START_BUTTON_G 0
@@ -252,8 +263,11 @@ void Interface_SetSceneRestrictions(struct PlayState* play);
 void Inventory_SwapAgeEquipment(void);
 void Interface_InitHorsebackArchery(struct PlayState* play);
 void func_800849EC(struct PlayState* play);
-void Interface_LoadItemIcon1(struct PlayState* play, u16 button);
-void Interface_LoadItemIcon2(struct PlayState* play, u16 button);
+void Interface_LoadItemIcon1(struct PlayState* play, u8 button);
+void Interface_LoadItemIcon2(struct PlayState* play, u8 button);
+void Interface_LoadItemIconDpad(struct PlayState* play, u8 button);
+u8 Interface_GetArrowFromDpad(u8 button);
+u8 Interface_GetItemFromDpad(u8 button);
 void func_80084BF4(struct PlayState* play, u16 flag);
 u8 Item_Give(struct PlayState* play, u8 item);
 u8 Item_CheckObtainability(u8 item);
@@ -282,5 +296,7 @@ void Interface_Init(struct PlayState* play);
 
 extern s16 gSpoilingItems[3];
 extern s16 gSpoilingItemReverts[3];
+extern u8 dpadStatus[4];
+extern u8 dpadAlphas[5];
 
 #endif

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -120,11 +120,11 @@ typedef struct InterfaceContext {
     /* 0x0240 */ u16    unk_240;
     /* 0x0242 */ u16    unk_242;
     /* 0x0224 */ u16    unk_244; // screen fill alpha?
-    /* 0x0246 */ u8     aAlpha; // also carrots alpha
-    /* 0x0248 */ u8     bAlpha; // also HBA score alpha
-    /* 0x024A */ u8     cLeftAlpha;
-    /* 0x024C */ u8     cDownAlpha;
-    /* 0x024E */ u8     cRightAlpha;
+    /* 0x0246 */ u16    aAlpha; // also carrots alpha
+    /* 0x0248 */ u16    bAlpha; // also HBA score alpha
+    /* 0x024A */ u16    cLeftAlpha;
+    /* 0x024C */ u16    cDownAlpha;
+    /* 0x024E */ u16    cRightAlpha;
     /* 0x0250 */ u16    healthAlpha; // also max C-Up alpha
     /* 0x0252 */ u16    magicAlpha; // also Rupee and Key counters alpha
     /* 0x0254 */ u16    minimapAlpha;

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -297,7 +297,7 @@ void Interface_ChangeDpadSet(struct PlayState* play);
 
 extern s16 gSpoilingItems[3];
 extern s16 gSpoilingItemReverts[3];
-extern u8 dpadStatus[4];
+extern bool dpadStatus[4];
 extern u8 dpadAlphas[5];
 
 #endif

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -300,5 +300,6 @@ extern s16 gSpoilingItemReverts[3];
 extern bool dpadStatus[4];
 extern u8 dpadAlphas[5];
 extern bool switchedDualSet;
+extern u8 sNoclipTimer;
 
 #endif

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -191,16 +191,14 @@ typedef struct InterfaceContext {
 #define C_UP_BUTTON_X 254 + (WIDESCREEN ? 104 : 0)
 #define C_UP_BUTTON_Y 16
 
-#define DPAD_X           (18     + 6)  // R_MAGIC_METER_X
-#define DPAD_Y           (42     + 30) // R_MAGIC_METER_Y_LOWER
-#define D_UP_BUTTON_X    (DPAD_X + 2)
-#define D_UP_BUTTON_Y    (DPAD_Y - 14)
-#define D_RIGHT_BUTTON_X (DPAD_X + 18)
-#define D_RIGHT_BUTTON_Y (DPAD_Y + 2)
-#define D_DOWN_BUTTON_X  (DPAD_X + 2)
-#define D_DOWN_BUTTON_Y  (DPAD_Y + 16)
-#define D_LEFT_BUTTON_X  (DPAD_X - 14)
-#define D_LEFT_BUTTON_Y  (DPAD_Y + 2)
+#define D_UP_BUTTON_X    (dpad_x + 2)
+#define D_UP_BUTTON_Y    (dpad_y - 14)
+#define D_RIGHT_BUTTON_X (dpad_x + 18)
+#define D_RIGHT_BUTTON_Y (dpad_y + 2)
+#define D_DOWN_BUTTON_X  (dpad_x + 2)
+#define D_DOWN_BUTTON_Y  (dpad_y + 16)
+#define D_LEFT_BUTTON_X  (dpad_x - 14)
+#define D_LEFT_BUTTON_Y  (dpad_y + 2)
 
 #if !PLATFORM_GC
 #define START_BUTTON_R 200

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -299,5 +299,6 @@ extern s16 gSpoilingItems[3];
 extern s16 gSpoilingItemReverts[3];
 extern bool dpadStatus[4];
 extern u8 dpadAlphas[5];
+extern bool switchedDualSet;
 
 #endif

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -264,7 +264,6 @@ void Interface_InitHorsebackArchery(struct PlayState* play);
 void func_800849EC(struct PlayState* play);
 void Interface_LoadItemIcon1(struct PlayState* play, u16 button);
 void Interface_LoadItemIcon2(struct PlayState* play, u16 button);
-void Interface_LoadItemIconDpad(struct PlayState* play, u8 button);
 u8 Interface_GetArrowFromDpad(u8 button);
 u8 Interface_GetItemFromDpad(u8 button);
 void func_80084BF4(struct PlayState* play, u16 flag);
@@ -292,7 +291,6 @@ void Interface_Draw(struct PlayState* play);
 void Interface_Update(struct PlayState* play);
 void Interface_Destroy(struct PlayState* play);
 void Interface_Init(struct PlayState* play);
-void ItemIcons_Init(struct PlayState* play, struct Player* player);
 void Interface_ChangeDpadSet(struct PlayState* play);
 
 extern s16 gSpoilingItems[3];

--- a/include/z64item.h
+++ b/include/z64item.h
@@ -148,6 +148,14 @@ typedef enum InventorySlot {
     /* 0x15 */ SLOT_BOTTLE_4,
     /* 0x16 */ SLOT_TRADE_ADULT,
     /* 0x17 */ SLOT_TRADE_CHILD,
+    /* 0x18 */ SLOT_SWORDS,
+    /* 0x19 */ SLOT_SHIELDS,
+    /* 0x1A */ SLOT_TUNICS,
+    /* 0x1B */ SLOT_BOOTS,
+    /* 0x1C */ SLOT_TUNIC_GORON,
+    /* 0x1D */ SLOT_TUNIC_ZORA,
+    /* 0x1E */ SLOT_BOOTS_IRON,
+    /* 0x20 */ SLOT_BOOTS_HOVER,
     /* 0xFF */ SLOT_NONE = 0xFF
 } InventorySlot;
 
@@ -308,6 +316,10 @@ typedef enum ItemID {
     /* 0x99 */ ITEM_DEKU_STICK_UPGRADE_30,
     /* 0x9A */ ITEM_DEKU_NUT_UPGRADE_30,
     /* 0x9B */ ITEM_DEKU_NUT_UPGRADE_40,
+    /* 0xEC */ ITEM_SWORDS,
+    /* 0xED */ ITEM_SHIELDS,
+    /* 0xEE */ ITEM_TUNICS,
+    /* 0xEF */ ITEM_BOOTS,
     /* 0xFC */ ITEM_SWORD_CS = 0xFC,
     /* 0xFE */ ITEM_NONE_FE = 0xFE,
     /* 0xFF */ ITEM_NONE = 0xFF

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -71,6 +71,12 @@ typedef enum MagicChangeType {
 #define MAGIC_NORMAL_METER 0x30
 #define MAGIC_DOUBLE_METER (2 * MAGIC_NORMAL_METER)
 
+typedef struct {
+        u8 itemId;
+        u8 equipId;
+        u8 requiredAge;
+} EquipmentSwapEntry;
+
 typedef struct ItemEquips {
     /* 0x00 */ u8 buttonItems[4];
     /* 0x04 */ u8 cButtonSlots[3];
@@ -181,6 +187,9 @@ typedef enum TimerId {
     /* 1 */ TIMER_ID_SUB, // See `subTimerState` and `subTimerSeconds`
     /* 2 */ TIMER_ID_MAX
 } TimerId;
+
+#define IS_ACTIVE_TIMER (gSaveContext.timerState    == TIMER_STATE_DOWN_TICK    || gSaveContext.timerState    == TIMER_STATE_UP_TICK    || gSaveContext.timerState == TIMER_STATE_UP_FREEZE || gSaveContext.timerState == TIMER_STATE_ENV_HAZARD_TICK || \
+                         gSaveContext.subTimerState == SUBTIMER_STATE_DOWN_TICK || gSaveContext.subTimerState == SUBTIMER_STATE_UP_TICK)
 
 #define MARATHON_TIME_LIMIT 240 // 4 minutes
 

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -474,6 +474,8 @@ typedef enum LinkAge {
 #define C_BTN_ITEM(button) ((gSaveContext.buttonStatus[(button) + 1] != BTN_DISABLED) \
                                 ? gSaveContext.save.info.equips.buttonItems[(button) + 1]       \
                                 : ITEM_NONE)
+                                
+#define D_BTN_ITEM(button) ((dpadStatus[button] != BTN_DISABLED) ? Interface_GetItemFromDpad(button) : ITEM_NONE)
 
 
 /*

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -227,7 +227,7 @@ typedef struct SavePlayerData {
     /* 0x1A  0x0036 */ u16 swordHealth;
     /* 0x1C  0x0038 */ u16 naviTimer;
     /* 0x1E  0x003A */ u8 isMagicAcquired;
-    /* 0x1F  0x003B */ char unk_3B[0x01];
+    /* 0x1F  0x003B */ u8 mask;
     /* 0x20  0x003C */ u8 isDoubleMagicAcquired;
     /* 0x21  0x003D */ u8 isDoubleDefenseAcquired;
     /* 0x22  0x003E */ u8 bgsFlag;
@@ -417,6 +417,13 @@ typedef enum LinkAge {
 
 #define LINK_IS_ADULT (gSaveContext.save.linkAge == LINK_AGE_ADULT)
 #define LINK_IS_CHILD (gSaveContext.save.linkAge == LINK_AGE_CHILD)
+
+#define SET_MASK_AGE(val)       ((LINK_IS_ADULT) ? SET_MASK_ADULT(val) : SET_MASK_CHILD(val))
+#define GET_MASK_AGE()          ((LINK_IS_ADULT) ? GET_MASK_ADULT()    : GET_MASK_CHILD())
+#define GET_MASK_ADULT()        ((u8)(((gSaveContext.save.info.playerData.mask) >> 8) & 0xFF))
+#define GET_MASK_CHILD()        ((u8)((gSaveContext.save.info.playerData.mask) & 0xFF))
+#define SET_MASK_ADULT(val)     (gSaveContext.save.info.playerData.mask = ((gSaveContext.save.info.playerData.mask & 0x00FF) | (((val) & 0xFF) << 8)))
+#define SET_MASK_CHILD(val)     (gSaveContext.save.info.playerData.mask = ((gSaveContext.save.info.playerData.mask & 0xFF00) | ((val) & 0xFF)))
 
 #define YEARS_CHILD 5
 #define YEARS_ADULT 17

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -408,12 +408,7 @@ typedef enum LinkAge {
     /* 1 */ LINK_AGE_CHILD
 } LinkAge;
 
-
-#define DPAD_BUTTONS(button)     (((u8*)gSaveContext.save.info.playerData.dpadItems)[button])
-#define IS_DPAD_DUAL_SET         (gSaveContext.save.info.playerData.dpadDualSet)
-#define CUR_DPAD_SET             (LINK_IS_CHILD + IS_DPAD_DUAL_SET * 2)
-#define DPAD_BUTTON(button)      (gSaveContext.save.info.playerData.dpadItems[CUR_DPAD_SET][button])
-#define DPAD_BUTTON_ITEM(button) (DPAD_BUTTON(button) < SLOT_SWORDS ? Interface_GetArrowFromDpad(button) : 0xFF)
+#define DPAD_BUTTON(button)      (gSaveContext.save.info.playerData.dpadItems[gSaveContext.save.linkAge + gSaveContext.save.info.playerData.dpadDualSet * 2][button])
 
 #define LINK_IS_ADULT (gSaveContext.save.linkAge == LINK_AGE_ADULT)
 #define LINK_IS_CHILD (gSaveContext.save.linkAge == LINK_AGE_CHILD)

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -227,14 +227,14 @@ typedef struct SavePlayerData {
     /* 0x1A  0x0036 */ u16 swordHealth;
     /* 0x1C  0x0038 */ u16 naviTimer;
     /* 0x1E  0x003A */ u8 isMagicAcquired;
-    /* 0x1F  0x003B */ u8 mask;
+    /* 0x1F  0x003B */ char unk_3B[0x01];
     /* 0x20  0x003C */ u8 isDoubleMagicAcquired;
     /* 0x21  0x003D */ u8 isDoubleDefenseAcquired;
     /* 0x22  0x003E */ u8 bgsFlag;
     /* 0x23  0x003F */ u8 ocarinaGameRoundNum;
     /* 0x24  0x0040 */ ItemEquips childEquips;
     /* 0x2E  0x004A */ ItemEquips adultEquips;
-    /* 0x38  0x0054 */ u8 unk_54; // this may be incorrect, currently used for alignment
+    /* 0x38  0x0054 */ u8 mask;
     /* 0x39  0x0055 */ u8 dpadDualSet;
     /* 0x3A  0x0056 */ u8 dpadItems[4][4];
     /* 0x4A  0x0066 */ s16 savedSceneId;

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -234,8 +234,9 @@ typedef struct SavePlayerData {
     /* 0x23  0x003F */ u8 ocarinaGameRoundNum;
     /* 0x24  0x0040 */ ItemEquips childEquips;
     /* 0x2E  0x004A */ ItemEquips adultEquips;
-    /* 0x38  0x0054 */ u32 unk_54; // this may be incorrect, currently used for alignment
-    /* 0x3C  0x0058 */ char unk_58[0x0E];
+    /* 0x38  0x0054 */ u8 unk_54; // this may be incorrect, currently used for alignment
+    /* 0x39  0x0055 */ u8 dpadDualSet;
+    /* 0x3A  0x0056 */ u8 dpadItems[4][4];
     /* 0x4A  0x0066 */ s16 savedSceneId;
 } SavePlayerData;
 
@@ -407,6 +408,12 @@ typedef enum LinkAge {
     /* 1 */ LINK_AGE_CHILD
 } LinkAge;
 
+
+#define DPAD_BUTTONS(button)     (((u8*)gSaveContext.save.info.playerData.dpadItems)[button])
+#define IS_DPAD_DUAL_SET         (gSaveContext.save.info.playerData.dpadDualSet)
+#define CUR_DPAD_SET             (LINK_IS_CHILD + IS_DPAD_DUAL_SET * 2)
+#define DPAD_BUTTON(button)      (gSaveContext.save.info.playerData.dpadItems[CUR_DPAD_SET][button])
+#define DPAD_BUTTON_ITEM(button) (DPAD_BUTTON(button) < SLOT_SWORDS ? Interface_GetArrowFromDpad(button) : 0xFF)
 
 #define LINK_IS_ADULT (gSaveContext.save.linkAge == LINK_AGE_ADULT)
 #define LINK_IS_CHILD (gSaveContext.save.linkAge == LINK_AGE_CHILD)

--- a/include/z64sram.h
+++ b/include/z64sram.h
@@ -34,5 +34,6 @@ void Sram_WriteSramHeader(SramContext* sramCtx);
 void Sram_InitSram(struct GameState* gameState, SramContext* sramCtx);
 void Sram_Alloc(struct GameState* gameState, SramContext* sramCtx);
 void Sram_Init(struct GameState* gameState, SramContext* sramCtx);
+u8 HasDuplicateDpadItems(void);
 
 #endif

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -35,8 +35,9 @@ void Interface_Init(PlayState* play) {
     interfaceCtx->lensMagicConsumptionTimer = 16;
     interfaceCtx->unk_228 = XREG(95);
     interfaceCtx->unk_244 = interfaceCtx->aAlpha = interfaceCtx->bAlpha = interfaceCtx->cLeftAlpha =
-        interfaceCtx->cDownAlpha = interfaceCtx->cRightAlpha = interfaceCtx->healthAlpha = interfaceCtx->startAlpha = dpadAlphas[0] = dpadAlphas[1] = dpadAlphas[2] = dpadAlphas[3] = dpadAlphas[4] = 
+        interfaceCtx->cDownAlpha = interfaceCtx->cRightAlpha = interfaceCtx->healthAlpha = interfaceCtx->startAlpha =
             interfaceCtx->magicAlpha = 0;
+    dpadAlphas[0] = dpadAlphas[1] = dpadAlphas[2] = dpadAlphas[3] = dpadAlphas[4] = 0;
     interfaceCtx->minimapAlpha = 0;
     interfaceCtx->unk_260 = 0;
 

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -183,21 +183,21 @@ void ItemIcons_Init(PlayState* play, Player* player) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     u8 item;
     u8 i;
-    
+
     for (i=0; i<8; i++) {
         if (i<4)
             item = gSaveContext.save.info.equips.buttonItems[i];
         else item = Interface_GetItemFromDpad(i-4);
-        
+
         if (item == ITEM_SWORDS)
-            item = (player->currentSwordItemId == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : player->currentSwordItemId;
+            item = player->currentSwordItemId;
         else if (item == ITEM_SHIELDS)
-            item = (player->currentShield == 0) ? ITEM_NONE : (ITEM_SHIELD_DEKU + player->currentShield - 1);
+            item = ITEM_SHIELD_DEKU + player->currentShield - 1;
         else if (item == ITEM_TUNICS)
             item = ITEM_TUNIC_KOKIRI + player->currentTunic;
         else if (item == ITEM_BOOTS)
             item = ITEM_BOOTS_KOKIRI + player->currentBoots;
-        
+
         if (item < 0xF0)
             DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 198);
     }

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -21,6 +21,8 @@ void Interface_Init(PlayState* play) {
     u32 parameterSize;
     u16 doActionOffset;
     u8 timerId;
+    u8 item;
+    u8 i;
 
     gSaveContext.sunsSongState = SUNSSONG_INACTIVE;
     gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
@@ -111,6 +113,24 @@ void Interface_Init(PlayState* play) {
            gSaveContext.save.info.equips.buttonItems[1], gSaveContext.save.info.equips.buttonItems[2],
            gSaveContext.save.info.equips.buttonItems[3]);
 
+    for (i=0; i<8; i++) {
+        if (i<4)
+            item = gSaveContext.save.info.equips.buttonItems[i];
+        else item = Interface_GetItemFromDpad(i-4);
+
+        if (item == ITEM_SWORDS)
+            item = gSaveContext.save.info.equips.buttonItems[0];
+        else if (item == ITEM_SHIELDS)
+            item = (SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD)) == PLAYER_SHIELD_NONE) ? ITEM_NONE : (ITEM_SHIELD_DEKU + SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD)) - 1);
+        else if (item == ITEM_TUNICS)
+            item = ITEM_TUNIC_KOKIRI + TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC));
+        else if (item == ITEM_BOOTS)
+            item = ITEM_BOOTS_KOKIRI + BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS));
+
+        if (item < 0xF0)
+            DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 198);
+    }
+
     PRINTF("ＥＶＥＮＴ＝%d\n", ((void)0, gSaveContext.timerState));
 
     if ((gSaveContext.timerState == TIMER_STATE_ENV_HAZARD_TICK) ||
@@ -177,30 +197,6 @@ void Interface_Init(PlayState* play) {
     R_A_BTN_COLOR(0) = A_BUTTON_R;
     R_A_BTN_COLOR(1) = A_BUTTON_G;
     R_A_BTN_COLOR(2) = A_BUTTON_B;
-}
-
-void ItemIcons_Init(PlayState* play, Player* player) {
-    InterfaceContext* interfaceCtx = &play->interfaceCtx;
-    u8 item;
-    u8 i;
-
-    for (i=0; i<8; i++) {
-        if (i<4)
-            item = gSaveContext.save.info.equips.buttonItems[i];
-        else item = Interface_GetItemFromDpad(i-4);
-
-        if (item == ITEM_SWORDS)
-            item = player->currentSwordItemId;
-        else if (item == ITEM_SHIELDS)
-            item = ITEM_SHIELD_DEKU + player->currentShield - 1;
-        else if (item == ITEM_TUNICS)
-            item = ITEM_TUNIC_KOKIRI + player->currentTunic;
-        else if (item == ITEM_BOOTS)
-            item = ITEM_BOOTS_KOKIRI + player->currentBoots;
-
-        if (item < 0xF0)
-            DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 198);
-    }
 }
 
 #define TEXTBOX_SEGMENT_SIZE \

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -9,7 +9,6 @@
 #include "z64ocarina.h"
 #include "z64play.h"
 #include "z64save.h"
-#include "z64player.h"
 
 void Interface_Destroy(PlayState* play) {
     Map_Destroy(play);
@@ -22,9 +21,6 @@ void Interface_Init(PlayState* play) {
     u32 parameterSize;
     u16 doActionOffset;
     u8 timerId;
-    u8 i;
-    u8 item;
-    Player* player = GET_PLAYER(play);
 
     gSaveContext.sunsSongState = SUNSSONG_INACTIVE;
     gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
@@ -114,27 +110,6 @@ void Interface_Init(PlayState* play) {
            gSaveContext.save.info.equips.buttonItems[1], gSaveContext.save.info.equips.buttonItems[2],
            gSaveContext.save.info.equips.buttonItems[3]);
 
-    for (i=0; i<4; i++) {
-        if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_SWORDS)
-            item = (player->currentSwordItemId == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : player->currentSwordItemId;
-        else if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_SHIELDS)
-            item = (player->currentShield == 0) ? ITEM_NONE : (ITEM_SHIELD_DEKU + player->currentShield - 1);
-        else if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_TUNICS)
-            item = ITEM_TUNIC_KOKIRI + player->currentTunic;
-        else if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_BOOTS)
-            item = ITEM_BOOTS_KOKIRI + player->currentBoots;
-        else item = gSaveContext.save.info.equips.buttonItems[i];
-        
-        if (gSaveContext.save.info.equips.buttonItems[i] < 0xF0)
-            DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 198);
-    }
-    
-    for (i=0; i<4; i++) {
-        item = Interface_GetItemFromDpad(i);
-        if (item < 0xF0)
-            DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + ( (4 + i) * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 219);
-    }
-
     PRINTF("ＥＶＥＮＴ＝%d\n", ((void)0, gSaveContext.timerState));
 
     if ((gSaveContext.timerState == TIMER_STATE_ENV_HAZARD_TICK) ||
@@ -201,6 +176,30 @@ void Interface_Init(PlayState* play) {
     R_A_BTN_COLOR(0) = A_BUTTON_R;
     R_A_BTN_COLOR(1) = A_BUTTON_G;
     R_A_BTN_COLOR(2) = A_BUTTON_B;
+}
+
+void ItemIcons_Init(PlayState* play, Player* player) {
+    InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    u8 item;
+    u8 i;
+    
+    for (i=0; i<8; i++) {
+        if (i<4)
+            item = gSaveContext.save.info.equips.buttonItems[i];
+        else item = Interface_GetItemFromDpad(i-4);
+        
+        if (item == ITEM_SWORDS)
+            item = (player->currentSwordItemId == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : player->currentSwordItemId;
+        else if (item == ITEM_SHIELDS)
+            item = (player->currentShield == 0) ? ITEM_NONE : (ITEM_SHIELD_DEKU + player->currentShield - 1);
+        else if (item == ITEM_TUNICS)
+            item = ITEM_TUNIC_KOKIRI + player->currentTunic;
+        else if (item == ITEM_BOOTS)
+            item = ITEM_BOOTS_KOKIRI + player->currentBoots;
+        
+        if (item < 0xF0)
+            DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 198);
+    }
 }
 
 #define TEXTBOX_SEGMENT_SIZE \

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -14,13 +14,15 @@ void Interface_Destroy(PlayState* play) {
     Map_Destroy(play);
 }
 
-#define ICON_ITEM_SEGMENT_SIZE (4 * ITEM_ICON_SIZE)
+#define ICON_ITEM_SEGMENT_SIZE (8 * ITEM_ICON_SIZE)
 
 void Interface_Init(PlayState* play) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     u32 parameterSize;
     u16 doActionOffset;
     u8 timerId;
+    u8 i;
+    u8 item;
 
     gSaveContext.sunsSongState = SUNSSONG_INACTIVE;
     gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
@@ -35,7 +37,7 @@ void Interface_Init(PlayState* play) {
     interfaceCtx->lensMagicConsumptionTimer = 16;
     interfaceCtx->unk_228 = XREG(95);
     interfaceCtx->unk_244 = interfaceCtx->aAlpha = interfaceCtx->bAlpha = interfaceCtx->cLeftAlpha =
-        interfaceCtx->cDownAlpha = interfaceCtx->cRightAlpha = interfaceCtx->healthAlpha = interfaceCtx->startAlpha =
+        interfaceCtx->cDownAlpha = interfaceCtx->cRightAlpha = interfaceCtx->healthAlpha = interfaceCtx->startAlpha = dpadAlphas[0] = dpadAlphas[1] = dpadAlphas[2] = dpadAlphas[3] = dpadAlphas[4] = 
             interfaceCtx->magicAlpha = 0;
     interfaceCtx->minimapAlpha = 0;
     interfaceCtx->unk_260 = 0;
@@ -138,6 +140,12 @@ void Interface_Init(PlayState* play) {
         DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (3 * ITEM_ICON_SIZE),
                          GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[3]), ITEM_ICON_SIZE,
                          "../z_construct.c", 219);
+    }
+    
+    for (i=0; i<4; i++) {
+        u8 item = Interface_GetItemFromDpad(i);
+        if (item < 0xF0)
+            DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + ( (4 + i) * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 219);
     }
 
     PRINTF("ＥＶＥＮＴ＝%d\n", ((void)0, gSaveContext.timerState));

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -9,6 +9,7 @@
 #include "z64ocarina.h"
 #include "z64play.h"
 #include "z64save.h"
+#include "z64player.h"
 
 void Interface_Destroy(PlayState* play) {
     Map_Destroy(play);
@@ -23,6 +24,7 @@ void Interface_Init(PlayState* play) {
     u8 timerId;
     u8 i;
     u8 item;
+    Player* player = GET_PLAYER(play);
 
     gSaveContext.sunsSongState = SUNSSONG_INACTIVE;
     gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
@@ -112,38 +114,23 @@ void Interface_Init(PlayState* play) {
            gSaveContext.save.info.equips.buttonItems[1], gSaveContext.save.info.equips.buttonItems[2],
            gSaveContext.save.info.equips.buttonItems[3]);
 
-    if (gSaveContext.save.info.equips.buttonItems[0] < 0xF0) {
-        DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (0 * ITEM_ICON_SIZE),
-
-                         GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[0]), ITEM_ICON_SIZE,
-                         "../z_construct.c", 198);
-    } else if (gSaveContext.save.info.equips.buttonItems[0] != 0xFF) {
-        DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (0 * ITEM_ICON_SIZE),
-
-                         GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[0]), ITEM_ICON_SIZE,
-                         "../z_construct.c", 203);
-    }
-
-    if (gSaveContext.save.info.equips.buttonItems[1] < 0xF0) {
-        DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (1 * ITEM_ICON_SIZE),
-                         GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[1]), ITEM_ICON_SIZE,
-                         "../z_construct.c", 209);
-    }
-
-    if (gSaveContext.save.info.equips.buttonItems[2] < 0xF0) {
-        DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (2 * ITEM_ICON_SIZE),
-                         GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[2]), ITEM_ICON_SIZE,
-                         "../z_construct.c", 214);
-    }
-
-    if (gSaveContext.save.info.equips.buttonItems[3] < 0xF0) {
-        DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (3 * ITEM_ICON_SIZE),
-                         GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[3]), ITEM_ICON_SIZE,
-                         "../z_construct.c", 219);
+    for (i=0; i<4; i++) {
+        if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_SWORDS)
+            item = (player->currentSwordItemId == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : player->currentSwordItemId;
+        else if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_SHIELDS)
+            item = (player->currentShield == 0) ? ITEM_NONE : (ITEM_SHIELD_DEKU + player->currentShield - 1);
+        else if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_TUNICS)
+            item = ITEM_TUNIC_KOKIRI + player->currentTunic;
+        else if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_BOOTS)
+            item = ITEM_BOOTS_KOKIRI + player->currentBoots;
+        else item = gSaveContext.save.info.equips.buttonItems[i];
+        
+        if (gSaveContext.save.info.equips.buttonItems[i] < 0xF0)
+            DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 198);
     }
     
     for (i=0; i<4; i++) {
-        u8 item = Interface_GetItemFromDpad(i);
+        item = Interface_GetItemFromDpad(i);
         if (item < 0xF0)
             DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + ( (4 + i) * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, "../z_construct.c", 219);
     }

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -84,7 +84,8 @@ void GameOver_Update(PlayState* play) {
             gSaveContext.eventInf[2] = 0;
             gSaveContext.eventInf[3] = 0;
             gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+                gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+            dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
             gSaveContext.forceRisingButtonAlphas = gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode =
                 gSaveContext.hudVisibilityModeTimer = 0; // false, HUD_VISIBILITY_NO_CHANGE
 

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -52,7 +52,7 @@ void GameOver_Update(PlayState* play) {
                         }
                     }
                     for (j=0; j<4; j++)
-                        if (DPAD_BUTTON_ITEM(j) == gSpoilingItemReverts[i])
+                        if (Interface_GetItemFromDpad(j) == gSpoilingItemReverts[i])
                             Interface_LoadItemIconDpad(play, j);
                 }
             }

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -53,7 +53,7 @@ void GameOver_Update(PlayState* play) {
                     }
                     for (j=0; j<4; j++)
                         if (Interface_GetItemFromDpad(j) == gSpoilingItemReverts[i])
-                            Interface_LoadItemIconDpad(play, j);
+                            Interface_LoadItemIcon1(play, j+4);
                 }
             }
 

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -51,6 +51,9 @@ void GameOver_Update(PlayState* play) {
                             Interface_LoadItemIcon1(play, j);
                         }
                     }
+                    for (j=0; j<4; j++)
+                        if (DPAD_BUTTON_ITEM(j) == gSpoilingItemReverts[i])
+                            Interface_LoadItemIconDpad(play, j);
                 }
             }
 
@@ -81,7 +84,7 @@ void GameOver_Update(PlayState* play) {
             gSaveContext.eventInf[2] = 0;
             gSaveContext.eventInf[3] = 0;
             gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+                gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
             gSaveContext.forceRisingButtonAlphas = gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode =
                 gSaveContext.hudVisibilityModeTimer = 0; // false, HUD_VISIBILITY_NO_CHANGE
 

--- a/src/code/z_inventory.c
+++ b/src/code/z_inventory.c
@@ -290,6 +290,8 @@ u8 Inventory_DeleteEquipment(PlayState* play, s16 equipment) {
     Player* player = GET_PLAYER(play);
     s32 pad;
     u16 equipValue = gSaveContext.save.info.equips.equipment & gEquipMasks[equipment];
+    u8 i;
+    u8 item;
 
     PRINTF(T("装備アイテム抹消 = %d  zzz=%d\n", "Erasing equipment item = %d  zzz=%d\n"), equipment, equipValue);
 
@@ -306,6 +308,23 @@ u8 Inventory_DeleteEquipment(PlayState* play, s16 equipment) {
         if (equipment == EQUIP_TYPE_SWORD) {
             gSaveContext.save.info.equips.buttonItems[0] = ITEM_NONE;
             gSaveContext.save.info.infTable[INFTABLE_INDEX_1DX] = 1;
+        }
+
+        if (equipment == EQUIP_TYPE_SWORD || equipment == EQUIP_TYPE_SHIELD)
+            for (i=1; i<4; i++)
+                if ( (gSaveContext.save.info.equips.buttonItems[i] == ITEM_SWORDS && equipment == EQUIP_TYPE_SWORD) || (gSaveContext.save.info.equips.buttonItems[i] == ITEM_SHIELDS && equipment == EQUIP_TYPE_SHIELD) ) {
+                    gSaveContext.save.info.equips.buttonItems[i]    = ITEM_NONE;
+                    gSaveContext.save.info.equips.cButtonSlots[i-1] = SLOT_NONE;
+                    break;
+                }
+
+        for (i=1; i<8; i++) {
+            if (i<4)
+                item = gSaveContext.save.info.equips.buttonItems[i];
+            else item = Interface_GetItemFromDpad(i-4);
+
+            if ( (item == ITEM_SWORDS && equipment == EQUIP_TYPE_SWORD) || (item == ITEM_SHIELDS && equipment == EQUIP_TYPE_SHIELD) || (item == ITEM_TUNICS && equipment == EQUIP_TYPE_TUNIC) || (item == ITEM_BOOTS && equipment == EQUIP_TYPE_BOOTS) )
+                Interface_LoadItemIcon1(play, i);
         }
 
         Player_SetEquipmentData(play, player);

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -454,7 +454,7 @@ void Minimap_Draw(PlayState* play) {
                     }
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (R_UPDATE_RATE * 20)) {
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (60 / R_UPDATE_RATE)) {
                     PRINTF("Game_play_demo_mode_check=%d\n", Play_InCsMode(play));
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
@@ -541,7 +541,7 @@ void Minimap_Draw(PlayState* play) {
                     Minimap_DrawCompassIcons(play); // Draw icons for the player spawn and current position
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (R_UPDATE_RATE * 20)) {
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (60 / R_UPDATE_RATE)) {
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
                                                                       &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -454,7 +454,7 @@ void Minimap_Draw(PlayState* play) {
                     }
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (60 / R_UPDATE_RATE)) {
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (60 / R_UPDATE_RATE) && sNoclipTimer == 0) {
                     PRINTF("Game_play_demo_mode_check=%d\n", Play_InCsMode(play));
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
@@ -541,7 +541,7 @@ void Minimap_Draw(PlayState* play) {
                     Minimap_DrawCompassIcons(play); // Draw icons for the player spawn and current position
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (60 / R_UPDATE_RATE)) {
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (60 / R_UPDATE_RATE) && sNoclipTimer == 0) {
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
                                                                       &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -454,7 +454,7 @@ void Minimap_Draw(PlayState* play) {
                     }
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < 60) {
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (R_UPDATE_RATE * 20)) {
                     PRINTF("Game_play_demo_mode_check=%d\n", Play_InCsMode(play));
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
@@ -541,7 +541,7 @@ void Minimap_Draw(PlayState* play) {
                     Minimap_DrawCompassIcons(play); // Draw icons for the player spawn and current position
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < 60) {
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < (R_UPDATE_RATE * 20)) {
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
                                                                       &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -413,7 +413,6 @@ void Minimap_Draw(PlayState* play) {
     s32 pad[2];
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     s32 mapIndex = gSaveContext.mapIndex;
-    u8 i;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_map_exp.c", 626);
 
@@ -455,17 +454,19 @@ void Minimap_Draw(PlayState* play) {
                     }
                 }
 
-                if (!Play_InCsMode(play)) {
-                    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R)) {
-                        Audio_PlaySfxGeneral(!gSaveContext.save.info.playerData.dpadDualSet ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-                        gSaveContext.save.info.playerData.dpadDualSet ^= 1;
-                        for (i=0; i<4; i++)
-                            Interface_LoadItemIconDpad(play, i);
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < 60) {
+                    PRINTF("Game_play_demo_mode_check=%d\n", Play_InCsMode(play));
+                    // clang-format off
+                    if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
+                                                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
+                                                                      &gSfxDefaultReverb);
+                    } else {
+                        Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4,
+                                               &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
+                                               &gSfxDefaultReverb);
                     }
-                    if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !pressed_r && minimap_timer < 60) {
-                        Audio_PlaySfxGeneral(!R_MINIMAP_DISABLED ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-                        R_MINIMAP_DISABLED ^= 1;
-                    }
+                    // clang-format on
+                    R_MINIMAP_DISABLED ^= 1;
                 }
 
                 break;
@@ -540,17 +541,18 @@ void Minimap_Draw(PlayState* play) {
                     Minimap_DrawCompassIcons(play); // Draw icons for the player spawn and current position
                 }
 
-                if (!Play_InCsMode(play)) {
-                    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R)) {
-                        Audio_PlaySfxGeneral(!gSaveContext.save.info.playerData.dpadDualSet ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-                        gSaveContext.save.info.playerData.dpadDualSet ^= 1;
-                        for (i=0; i<4; i++)
-                            Interface_LoadItemIconDpad(play, i);
+                if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !Play_InCsMode(play) && !pressed_r && minimap_timer < 60) {
+                    // clang-format off
+                    if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
+                                                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
+                                                                      &gSfxDefaultReverb);
+                    } else {
+                        Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4,
+                                               &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
+                                               &gSfxDefaultReverb);
                     }
-                    if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !pressed_r && minimap_timer < 60) {
-                        Audio_PlaySfxGeneral(!R_MINIMAP_DISABLED ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-                        R_MINIMAP_DISABLED ^= 1;
-                    }
+                    // clang-format on
+                    R_MINIMAP_DISABLED ^= 1;
                 }
 
                 break;

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -26,8 +26,8 @@ s16 sPlayerInitialPosX = 0;
 s16 sPlayerInitialPosZ = 0;
 s16 sPlayerInitialDirection = 0;
 s16 sEntranceIconMapIndex = 0;
-u8 minimap_timer = 0;
-u8 pressed_r = false;
+static u8 minimap_timer = 0;
+static bool pressed_r = false;
 
 void Map_SavePlayerInitialInfo(PlayState* play) {
     Player* player = GET_PLAYER(play);

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -26,6 +26,8 @@ s16 sPlayerInitialPosX = 0;
 s16 sPlayerInitialPosZ = 0;
 s16 sPlayerInitialDirection = 0;
 s16 sEntranceIconMapIndex = 0;
+u8 minimap_timer = 0;
+u8 pressed_r = false;
 
 void Map_SavePlayerInitialInfo(PlayState* play) {
     Player* player = GET_PLAYER(play);
@@ -411,6 +413,7 @@ void Minimap_Draw(PlayState* play) {
     s32 pad[2];
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     s32 mapIndex = gSaveContext.mapIndex;
+    u8 i;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_map_exp.c", 626);
 
@@ -452,19 +455,17 @@ void Minimap_Draw(PlayState* play) {
                     }
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].press.button, BTN_L) && !Play_InCsMode(play)) {
-                    PRINTF("Game_play_demo_mode_check=%d\n", Play_InCsMode(play));
-                    // clang-format off
-                    if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
-                                                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
-                                                                      &gSfxDefaultReverb);
-                    } else {
-                        Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4,
-                                               &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
-                                               &gSfxDefaultReverb);
+                if (!Play_InCsMode(play)) {
+                    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R)) {
+                        Audio_PlaySfxGeneral(!gSaveContext.save.info.playerData.dpadDualSet ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                        gSaveContext.save.info.playerData.dpadDualSet ^= 1;
+                        for (i=0; i<4; i++)
+                            Interface_LoadItemIconDpad(play, i);
                     }
-                    // clang-format on
-                    R_MINIMAP_DISABLED ^= 1;
+                    if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !pressed_r && minimap_timer < 60) {
+                        Audio_PlaySfxGeneral(!R_MINIMAP_DISABLED ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                        R_MINIMAP_DISABLED ^= 1;
+                    }
                 }
 
                 break;
@@ -539,23 +540,29 @@ void Minimap_Draw(PlayState* play) {
                     Minimap_DrawCompassIcons(play); // Draw icons for the player spawn and current position
                 }
 
-                if (CHECK_BTN_ALL(play->state.input[0].press.button, BTN_L) && !Play_InCsMode(play)) {
-                    // clang-format off
-                    if (!R_MINIMAP_DISABLED) { Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &gSfxDefaultPos, 4,
-                                                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
-                                                                      &gSfxDefaultReverb);
-                    } else {
-                        Audio_PlaySfxGeneral(NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4,
-                                               &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
-                                               &gSfxDefaultReverb);
+                if (!Play_InCsMode(play)) {
+                    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R)) {
+                        Audio_PlaySfxGeneral(!gSaveContext.save.info.playerData.dpadDualSet ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                        gSaveContext.save.info.playerData.dpadDualSet ^= 1;
+                        for (i=0; i<4; i++)
+                            Interface_LoadItemIconDpad(play, i);
                     }
-                    // clang-format on
-                    R_MINIMAP_DISABLED ^= 1;
+                    if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L) && !pressed_r && minimap_timer < 60) {
+                        Audio_PlaySfxGeneral(!R_MINIMAP_DISABLED ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                        R_MINIMAP_DISABLED ^= 1;
+                    }
                 }
 
                 break;
         }
     }
+
+    if (CHECK_BTN_ALL(play->state.input[0].press.button, BTN_R))
+        pressed_r = 1;
+    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && minimap_timer < 255)
+        minimap_timer++;
+    if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L))
+        minimap_timer = pressed_r = 0;
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_map_exp.c", 782);
 }

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -3186,9 +3186,9 @@ void Interface_DrawItemButtons(PlayState* play) {
 
     // D-Pad positions
     dpad_x = R_MAGIC_METER_X + 6;
-    dpad_y = (gSaveContext.save.info.playerData.healthCapacity > 0xA0) ? R_MAGIC_METER_Y_LOWER : R_MAGIC_METER_Y_HIGHER;
+    dpad_y = ( (gSaveContext.save.info.playerData.healthCapacity > 0xA0) ? R_MAGIC_METER_Y_LOWER : R_MAGIC_METER_Y_HIGHER) + 15;
     if (gSaveContext.save.info.playerData.magicLevel != 0)
-        dpad_y += 30;
+        dpad_y += 15;
     if ( (gSaveContext.timerState == TIMER_STATE_ENV_HAZARD_TICK || gSaveContext.timerState == TIMER_STATE_DOWN_TICK || gSaveContext.timerState == TIMER_STATE_UP_TICK || gSaveContext.timerState == TIMER_STATE_UP_FREEZE) && pauseCtx->state == PAUSE_STATE_OFF)
         dpad_y += 15;
 

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -827,7 +827,7 @@ void func_80083108(PlayState* play) {
                 for (i = 1; i < 4; i++) {
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
                         if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT) && !Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i])) {
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT) && (gSaveContext.save.info.equips.buttonItems[i] < ITEM_MASK_KEATON || gSaveContext.save.info.equips.buttonItems[i] > ITEM_MASK_TRUTH) && !Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i])) {
                             if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
                                 sp28 = true;
                             }
@@ -840,8 +840,8 @@ void func_80083108(PlayState* play) {
 
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         }
-                    } else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i]  < ITEM_MASK_KEATON || gSaveContext.save.info.equips.buttonItems[i]  > ITEM_MASK_TRUTH) && !Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i])) {
+                    } else if (Player_GetEnvironmentalHazard(play) >= PLAYER_ENV_HAZARD_SWIMMING) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i]  < ITEM_MASK_KEATON || gSaveContext.save.info.equips.buttonItems[i] > ITEM_MASK_TRUTH) && !Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i])) {
                             if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
                                 sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_DISABLED;
@@ -861,7 +861,7 @@ void func_80083108(PlayState* play) {
                 }
                 for (i=0; i<4; i++) {
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
-                        if (Interface_GetItemFromDpad(i) != ITEM_HOOKSHOT && Interface_GetItemFromDpad(i) != ITEM_LONGSHOT && !Interface_IsEquipmentItem(Interface_GetItemFromDpad(i))) {
+                        if (Interface_GetItemFromDpad(i) != ITEM_HOOKSHOT && Interface_GetItemFromDpad(i) != ITEM_LONGSHOT && (Interface_GetItemFromDpad(i) < ITEM_MASK_KEATON || Interface_GetItemFromDpad(i) > ITEM_MASK_TRUTH) && !Interface_IsEquipmentItem(Interface_GetItemFromDpad(i))) {
                             if (dpadStatus[i] == BTN_ENABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_DISABLED;
@@ -871,7 +871,7 @@ void func_80083108(PlayState* play) {
                             dpadStatus[i] = BTN_ENABLED;
                         }
                     }
-                    else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
+                    else if (Player_GetEnvironmentalHazard(play) >= PLAYER_ENV_HAZARD_SWIMMING) {
                         if (((Interface_GetItemFromDpad(i) < ITEM_MASK_KEATON || Interface_GetItemFromDpad(i) > ITEM_MASK_TRUTH)) && !Interface_IsEquipmentItem(Interface_GetItemFromDpad(i))) {
                             if (dpadStatus[i] == BTN_ENABLED)
                                 sp28 = true;

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -28,6 +28,7 @@
 #include "assets/textures/parameter_static/parameter_static.h"
 #include "assets/textures/do_action_static/do_action_static.h"
 #include "assets/textures/icon_item_static/icon_item_static.h"
+#include "assets/textures/nes_font_static/nes_font_static.h"
 
 typedef struct RestrictionFlags {
     /* 0x00 */ u8 sceneId;
@@ -155,7 +156,7 @@ static s16 sMagicBorderB = 255;
 
 u8 dpadStatus[] = { BTN_ENABLED, BTN_ENABLED, BTN_ENABLED, BTN_ENABLED };
 u8 dpadAlphas[] = { 0, 0, 0, 0, 0 };
-
+u8 pressed_z    = false;
 u16 dpad_x;
 u16 dpad_y;
 
@@ -260,7 +261,7 @@ void Interface_RaiseButtonAlphas(PlayState* play, s16 risingAlpha) {
             interfaceCtx->aAlpha = risingAlpha;
         }
     }
-    
+
     if (dpadStatus[0] == BTN_DISABLED && dpadStatus[1] == BTN_DISABLED && dpadStatus[2] == BTN_DISABLED && dpadStatus[3] == BTN_DISABLED) {
         if (dpadAlphas[0] != 70)
             dpadAlphas[0] = 70;
@@ -317,7 +318,7 @@ void Interface_DimButtonAlphas(PlayState* play, s16 dimmingAlpha, s16 risingAlph
     if ((interfaceCtx->cRightAlpha != 0) && (interfaceCtx->cRightAlpha > dimmingAlpha)) {
         interfaceCtx->cRightAlpha = dimmingAlpha;
     }
-    
+
     updateDpadAlphas(dimmingAlpha);
 }
 
@@ -816,19 +817,23 @@ void func_80083108(PlayState* play) {
 
                 gSaveContext.buttonStatus[0] = BTN_DISABLED;
 
-                for (i=1; i<4; i++) {
+                for (i = 1; i < 4; i++) {
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
-                        if (gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT && gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
+                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
                                 sp28 = true;
+                            }
+
                             gSaveContext.buttonStatus[i] = BTN_DISABLED;
                         } else {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
                                 sp28 = true;
+                            }
+
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         }
-                    }
-                    else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
+                    } else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
                         if (gSaveContext.save.info.equips.buttonItems[i] < ITEM_MASK_KEATON || gSaveContext.save.info.equips.buttonItems[i] > ITEM_MASK_TRUTH) {
                             if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
                                 sp28 = true;
@@ -839,10 +844,11 @@ void func_80083108(PlayState* play) {
                                 sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         }
-                    }
-                    else {
-                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
+                    } else {
+                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
                             sp28 = true;
+                        }
+
                         gSaveContext.buttonStatus[i] = BTN_DISABLED;
                     }
                 }
@@ -889,7 +895,6 @@ void func_80083108(PlayState* play) {
                     gSaveContext.buttonStatus[2] = BTN_DISABLED;
                     gSaveContext.buttonStatus[3] = BTN_DISABLED;
                     dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
-                    
                     gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                     Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
                 }
@@ -925,15 +930,19 @@ void func_80083108(PlayState* play) {
                     sp28 = false;
                 }
 
-                for (i=1; i<4; i++) {
-                    if (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY && gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME) {
-                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
+                for (i = 1; i < 4; i++) {
+                    if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY) &&
+                        (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME)) {
+                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
                             sp28 = true;
+                        }
+
                         gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                    }
-                    else {
-                        if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
+                    } else {
+                        if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
                             sp28 = true;
+                        }
+
                         gSaveContext.buttonStatus[i] = BTN_ENABLED;
                     }
                 }
@@ -1020,7 +1029,7 @@ void func_80083108(PlayState* play) {
                         dpadStatus[i] = status;
                     }
                 }
-            
+
                 status = !interfaceCtx->restrictions.tradeItems;
                 for (i=1; i<4; i++) {
                     item = gSaveContext.save.info.equips.buttonItems[i];
@@ -1038,7 +1047,7 @@ void func_80083108(PlayState* play) {
                         dpadStatus[i] = status;
                     }
                 }
-            
+
                 status = !interfaceCtx->restrictions.hookshot;
                 for (i=1; i<4; i++) {
                     item = gSaveContext.save.info.equips.buttonItems[i];
@@ -1056,7 +1065,7 @@ void func_80083108(PlayState* play) {
                         dpadStatus[i] = status;
                     }
                 }
-            
+
                 status = !interfaceCtx->restrictions.ocarina;
                 for (i=1; i<4; i++) {
                     item = gSaveContext.save.info.equips.buttonItems[i];
@@ -1074,7 +1083,7 @@ void func_80083108(PlayState* play) {
                         dpadStatus[i] = status;
                     }
                 }
-            
+
                 status = !interfaceCtx->restrictions.farores;
                 for (i=1; i<4; i++) {
                     item = gSaveContext.save.info.equips.buttonItems[i];
@@ -1092,7 +1101,7 @@ void func_80083108(PlayState* play) {
                         dpadStatus[i] = status;
                     }
                 }
-            
+
                 status = !interfaceCtx->restrictions.dinsNayrus;
                 for (i=1; i<4; i++) {
                     item = gSaveContext.save.info.equips.buttonItems[i];
@@ -1110,11 +1119,11 @@ void func_80083108(PlayState* play) {
                         dpadStatus[i] = status;
                     }
                 }
-                
+
                 if (interfaceCtx->restrictions.all) {
                     for (i=1; i<4; i++) {
                         item = gSaveContext.save.info.equips.buttonItems[i];
-                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
                             if (play->sceneId != SCENE_TREASURE_BOX_SHOP || gSaveContext.save.info.equips.buttonItems[i] != ITEM_LENS_OF_TRUTH) {
                                 if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
                                     sp28 = true;
@@ -1129,7 +1138,7 @@ void func_80083108(PlayState* play) {
                     }
                     for (i=0; i<4; i++) {
                         item = Interface_GetItemFromDpad(i);
-                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
                             if (play->sceneId != SCENE_TREASURE_BOX_SHOP || item != ITEM_LENS_OF_TRUTH) {
                                 if (dpadStatus[i] == BTN_ENABLED)
                                     sp28 = true;
@@ -1146,7 +1155,7 @@ void func_80083108(PlayState* play) {
                 else if (!interfaceCtx->restrictions.all) {
                     for (i=1; i<4; i++) {
                         item = gSaveContext.save.info.equips.buttonItems[i];
-                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
                             if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
                                 sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
@@ -1154,7 +1163,7 @@ void func_80083108(PlayState* play) {
                     }
                     for (i=0; i<4; i++) {
                         item = Interface_GetItemFromDpad(i);
-                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
                             if (dpadStatus[i] == BTN_DISABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_ENABLED;
@@ -1392,7 +1401,7 @@ void func_800849EC(PlayState* play) {
     Interface_LoadItemIcon1(play, 0);
 }
 
-void Interface_LoadItemIcon1(PlayState* play, u8 button) {
+void Interface_LoadItemIcon1(PlayState* play, u16 button) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     Player* player = GET_PLAYER(play);
     u8 item;
@@ -1408,11 +1417,13 @@ void Interface_LoadItemIcon1(PlayState* play, u8 button) {
     else item = gSaveContext.save.info.equips.buttonItems[button];
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
-    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (button * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1171);
+    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (button * ITEM_ICON_SIZE),
+                      GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0,
+                      &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1171);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
 
-void Interface_LoadItemIcon2(PlayState* play, u8 button) {
+void Interface_LoadItemIcon2(PlayState* play, u16 button) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
@@ -1517,13 +1528,14 @@ void func_80084BF4(PlayState* play, u16 flag) {
 }
 
 u8 Item_Give(PlayState* play, u8 item) {
-    static u8 sAmmoRefillCounts[] = { 5, 10, 20, 30 }; // Sticks, nuts, bombs
-    static u8 sArrowRefillCounts[] = { 5, 10, 30 };
-    static u8 sBombchuRefillCounts[] = { 5, 20 };
-    static u8 sRupeeRefillCounts[] = { 1, 5, 20, 50, 200, 10 };
-    u8 i, j;
-    u8 slot;
-    u8 temp;
+    static s16 sAmmoRefillCounts[] = { 5, 10, 20, 30 }; // Sticks, nuts, bombs
+    static s16 sArrowRefillCounts[] = { 5, 10, 30 };
+    static s16 sBombchuRefillCounts[] = { 5, 20 };
+    static s16 sRupeeRefillCounts[] = { 1, 5, 20, 50, 200, 10 };
+    s16 i;
+    s16 j;
+    s16 slot;
+    s16 temp;
 
     slot = SLOT(item);
     if (item >= ITEM_DEKU_STICKS_5) {
@@ -2021,9 +2033,9 @@ u8 Item_Give(PlayState* play, u8 item) {
 }
 
 u8 Item_CheckObtainability(u8 item) {
-    u8 i;
-    u8 slot = SLOT(item);
-    u8 temp;
+    s16 i;
+    s16 slot = SLOT(item);
+    s16 temp;
 
     if (item >= ITEM_DEKU_STICKS_5) {
         slot = SLOT(sExtraItemBases[item - ITEM_DEKU_STICKS_5]);
@@ -2167,7 +2179,7 @@ void Inventory_DeleteItem(u16 item, u16 invSlot) {
 }
 
 s32 Inventory_ReplaceItem(PlayState* play, u16 oldItem, u16 newItem) {
-    u8 i;
+    s16 i;
 
     for (i = 0; i < ARRAY_COUNT(gSaveContext.save.info.inventory.items); i++) {
         if (gSaveContext.save.info.inventory.items[i] == oldItem) {
@@ -2258,9 +2270,9 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
 }
 
 s32 Inventory_ConsumeFairy(PlayState* play) {
-    u8 bottleSlot = SLOT(ITEM_BOTTLE_FAIRY);
-    u8 i;
-    u8 j;
+    s32 bottleSlot = SLOT(ITEM_BOTTLE_FAIRY);
+    s16 i;
+    s16 j;
 
     for (i = 0; i < 4; i++) {
         if (gSaveContext.save.info.inventory.items[bottleSlot + i] == ITEM_BOTTLE_FAIRY) {
@@ -2774,11 +2786,7 @@ void Magic_Update(PlayState* play) {
                      (Player_GetEnvironmentalHazard(play) <= PLAYER_ENV_HAZARD_UNDERWATER_FREE)) ||
                     ((gSaveContext.save.info.equips.buttonItems[1] != ITEM_LENS_OF_TRUTH) &&
                      (gSaveContext.save.info.equips.buttonItems[2] != ITEM_LENS_OF_TRUTH) &&
-                     (gSaveContext.save.info.equips.buttonItems[3] != ITEM_LENS_OF_TRUTH) &&
-                     (DPAD_BUTTON_ITEM(0)                          != ITEM_LENS_OF_TRUTH) &&
-                     (DPAD_BUTTON_ITEM(1)                          != ITEM_LENS_OF_TRUTH) &&
-                     (DPAD_BUTTON_ITEM(2)                          != ITEM_LENS_OF_TRUTH) &&
-                     (DPAD_BUTTON_ITEM(3)                          != ITEM_LENS_OF_TRUTH)) ||
+                     (gSaveContext.save.info.equips.buttonItems[3] != ITEM_LENS_OF_TRUTH) && (DPAD_BUTTON_ITEM(0) != ITEM_LENS_OF_TRUTH) && (DPAD_BUTTON_ITEM(1) != ITEM_LENS_OF_TRUTH) && (DPAD_BUTTON_ITEM(2) != ITEM_LENS_OF_TRUTH) && (DPAD_BUTTON_ITEM(3) != ITEM_LENS_OF_TRUTH)) ||
                     !play->actorCtx.lensActive) {
                     // Force lens off and set magic meter state to idle
                     play->actorCtx.lensActive = false;
@@ -3041,8 +3049,6 @@ void Interface_DrawItemButtons(PlayState* play) {
     s16 width;
     s16 height;
 #endif
-    u16 b_button_dd = 575;
-    u16 c_button_dd = 620;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 2900);
 
@@ -3059,7 +3065,7 @@ void Interface_DrawItemButtons(PlayState* play) {
     else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 192, 192, 192, dpadAlphas[0]);
     gDPLoadTextureBlock(OVERLAY_DISP++, gDpadTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
     gSPTextureRectangle(OVERLAY_DISP++, (dpad_x) << 2, (dpad_y) << 2, (dpad_x + 16) << 2, (dpad_y + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
-    
+
     // B Button Color & Texture
     // Also loads the Item Button Texture reused by other buttons afterwards
     gDPPipeSync(OVERLAY_DISP++);
@@ -3068,7 +3074,7 @@ void Interface_DrawItemButtons(PlayState* play) {
     gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
     OVERLAY_DISP =
         Gfx_TextureIA8(OVERLAY_DISP, gButtonBackgroundTex, 32, 32, R_ITEM_BTN_X(0), R_ITEM_BTN_Y(0),
-                       R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_WIDTH(0), b_button_dd << 1, b_button_dd << 1);
+                       R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_DD(0) << 1, R_ITEM_BTN_DD(0) << 1);
 
     // C-Left Button Color & Texture
     gDPPipeSync(OVERLAY_DISP++);
@@ -3076,21 +3082,21 @@ void Interface_DrawItemButtons(PlayState* play) {
                     interfaceCtx->cLeftAlpha);
     gSPTextureRectangle(OVERLAY_DISP++, R_ITEM_BTN_X(1) << 2, R_ITEM_BTN_Y(1) << 2,
                         (R_ITEM_BTN_X(1) + R_ITEM_BTN_WIDTH(1)) << 2, (R_ITEM_BTN_Y(1) + R_ITEM_BTN_WIDTH(1)) << 2,
-                        G_TX_RENDERTILE, 0, 0, c_button_dd << 1, c_button_dd << 1);
+                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(1) << 1, R_ITEM_BTN_DD(1) << 1);
 
     // C-Down Button Color & Texture
     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
                     interfaceCtx->cDownAlpha);
     gSPTextureRectangle(OVERLAY_DISP++, R_ITEM_BTN_X(2) << 2, R_ITEM_BTN_Y(2) << 2,
-                        (R_ITEM_BTN_X(2) + R_ITEM_BTN_WIDTH(1)) << 2, (R_ITEM_BTN_Y(2) + R_ITEM_BTN_WIDTH(1)) << 2,
-                        G_TX_RENDERTILE, 0, 0, c_button_dd << 1, c_button_dd << 1);
+                        (R_ITEM_BTN_X(2) + R_ITEM_BTN_WIDTH(2)) << 2, (R_ITEM_BTN_Y(2) + R_ITEM_BTN_WIDTH(2)) << 2,
+                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(2) << 1, R_ITEM_BTN_DD(2) << 1);
 
     // C-Right Button Color & Texture
     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
                     interfaceCtx->cRightAlpha);
     gSPTextureRectangle(OVERLAY_DISP++, R_ITEM_BTN_X(3) << 2, R_ITEM_BTN_Y(3) << 2,
-                        (R_ITEM_BTN_X(3) + R_ITEM_BTN_WIDTH(1)) << 2, (R_ITEM_BTN_Y(3) + R_ITEM_BTN_WIDTH(1)) << 2,
-                        G_TX_RENDERTILE, 0, 0, c_button_dd << 1, c_button_dd << 1);
+                        (R_ITEM_BTN_X(3) + R_ITEM_BTN_WIDTH(3)) << 2, (R_ITEM_BTN_Y(3) + R_ITEM_BTN_WIDTH(3)) << 2,
+                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(3) << 1, R_ITEM_BTN_DD(3) << 1);
 
     if (!IS_PAUSE_STATE_GAMEOVER(pauseCtx)) {
         if (IS_PAUSED(&play->pauseCtx)) {
@@ -3212,14 +3218,14 @@ void Interface_DrawItemButtons(PlayState* play) {
 
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex + ((32 * 32) * (temp + 1))), 32, 32,
                                           R_ITEM_BTN_X(temp), R_ITEM_BTN_Y(temp), R_ITEM_BTN_WIDTH(temp),
-                                          R_ITEM_BTN_WIDTH(temp), c_button_dd << 1, c_button_dd << 1);
+                                          R_ITEM_BTN_WIDTH(temp), R_ITEM_BTN_DD(temp) << 1, R_ITEM_BTN_DD(temp) << 1);
         }
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_parameter.c", 3071);
 }
 
-void Interface_DrawItemIconTexture(PlayState* play, void* texture, u8 button) {
+void Interface_DrawItemIconTexture(PlayState* play, void* texture, s16 button) {
     u16 x;
     u16 y;
     u16 dd;
@@ -3280,7 +3286,7 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
     s16 ammo;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 3105);
-    
+
     if (button < 4)
         i = gSaveContext.save.info.equips.buttonItems[button];
     else i = DPAD_BUTTON_ITEM(button-4);
@@ -3324,10 +3330,10 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
             i++;
             ammo -= 10;
         }
-        
+
         if (button < 4) {
             if (i != 0)
-                OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8, R_ITEM_AMMO_X(button),     R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
+                OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8, R_ITEM_AMMO_X(button), R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * ammo)), 8, 8, R_ITEM_AMMO_X(button) + 6, R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
         }
         else {
@@ -3350,7 +3356,7 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
                     y = D_LEFT_BUTTON_Y + 8;
                     break;
             }
-            
+
             if (i != 0)
                 OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8, x, y, 6, 6, 1 << 11, 1 << 11);
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * ammo)), 8, 8, x + 3, y, 6, 6, 1 << 11, 1 << 11);
@@ -3731,7 +3737,7 @@ void Interface_Draw(PlayState* play) {
                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
             Interface_DrawAmmoCount(play, 3, interfaceCtx->cRightAlpha);
         }
-        
+
         for (svar1=0; svar1<4; svar1++) {
             gDPPipeSync(OVERLAY_DISP++);
            
@@ -4771,4 +4777,22 @@ void Interface_Update(PlayState* play) {
             gSaveContext.sunsSongState = SUNSSONG_SPECIAL;
         }
     }
+}
+
+void Interface_ChangeDpadSet(PlayState* play) {
+    u8 i;
+    
+    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R) && !pressed_z && gSaveContext.minigameState == 0 && !IS_CUTSCENE_LAYER) {
+        Audio_PlaySfxGeneral(!gSaveContext.save.info.playerData.dpadDualSet ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        gSaveContext.save.info.playerData.dpadDualSet ^= 1;
+        for (i=0; i<4; i++) {
+            Interface_LoadItemIconDpad(play, i);
+            dpadStatus[i] = BTN_ENABLED;
+        }
+        gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode;
+    }
+    if (!IS_PAUSED(&play->pauseCtx) && &play->pauseCtx.debugState == 0 && CHECK_BTN_ALL(play->state.input[0].press.button, BTN_Z))
+        pressed_z = 1;
+    if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L))
+        pressed_z = 0;
 }

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -3193,9 +3193,11 @@ void Interface_DrawItemButtons(PlayState* play) {
         dpad_y += 15;
 
     if (Interface_GetItemFromDpad(0) != ITEM_NONE || Interface_GetItemFromDpad(1) != ITEM_NONE || Interface_GetItemFromDpad(2) != ITEM_NONE || Interface_GetItemFromDpad(3) != ITEM_NONE) {
-        if (gSaveContext.save.info.playerData.dpadDualSet)
+        if (gSaveContext.save.info.playerData.dpadDualSet) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[0]);
-        else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 192, 192, 192, dpadAlphas[0]);
+        } else {
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 192, 192, 192, dpadAlphas[0]);
+        }
         gDPLoadTextureBlock(OVERLAY_DISP++, gDpadTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSPTextureRectangle(OVERLAY_DISP++, (dpad_x) << 2, (dpad_y) << 2, (dpad_x + 16) << 2, (dpad_y + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
     }

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1547,27 +1547,29 @@ void func_800849EC(PlayState* play) {
         }
         else {
             if (DPAD_BUTTON(i-4) == SLOT_SWORDS)
-                Interface_LoadItemIconDpad(play, i-4);
+                Interface_LoadItemIcon1(play, i);
         }
     }
 }
 
 void Interface_LoadItemIcon1(PlayState* play, u16 button) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
-    Player* player = GET_PLAYER(play);
     u8 item;
 
-    if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_SWORDS)
-        item = (gSaveContext.save.info.equips.buttonItems[0] == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : B_BTN_ITEM;
-    else if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_SHIELDS)
-        item = ITEM_SHIELD_DEKU + SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD)) - 1;
-    else if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_TUNICS)
-        item = ITEM_TUNIC_KOKIRI + TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC));
-    else if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_BOOTS)
-        item = ITEM_BOOTS_KOKIRI + BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS));
-    else item = gSaveContext.save.info.equips.buttonItems[button];
+    if (button < 4)
+        item = gSaveContext.save.info.equips.buttonItems[button];
+    else item = Interface_GetItemFromDpad(button-4);
 
-    if (item == ITEM_NONE)
+    if (item == ITEM_SWORDS)
+        item = gSaveContext.save.info.equips.buttonItems[0];
+    else if (item == ITEM_SHIELDS)
+        item = (SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD)) == PLAYER_SHIELD_NONE) ? ITEM_NONE : (ITEM_SHIELD_DEKU + SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD)) - 1);
+    else if (item == ITEM_TUNICS)
+        item = ITEM_TUNIC_KOKIRI + TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC));
+    else if (item == ITEM_BOOTS)
+        item = ITEM_BOOTS_KOKIRI + BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS));
+
+    if (item >= 0xF0)
         return;
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
@@ -1587,43 +1589,12 @@ void Interface_LoadItemIcon2(PlayState* play, u16 button) {
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
 
-void Interface_LoadItemIconDpad(PlayState* play, u8 button) {
-    InterfaceContext* interfaceCtx = &play->interfaceCtx;
-    Player* player = GET_PLAYER(play);
-    u8 item;
-
-    if (DPAD_BUTTON(button) < SLOT_SWORDS)
-        item = Interface_GetItemFromDpad(button);
-    else if (DPAD_BUTTON(button) == SLOT_SWORDS)
-        item = (gSaveContext.save.info.equips.buttonItems[0] == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : B_BTN_ITEM;
-    else if (DPAD_BUTTON(button) == SLOT_SHIELDS)
-        item = ITEM_SHIELD_DEKU + SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD)) - 1;
-    else if (DPAD_BUTTON(button) == SLOT_TUNICS)
-        item = ITEM_TUNIC_KOKIRI + TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC));
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS)
-        item = ITEM_BOOTS_KOKIRI + BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS));
-    else if (DPAD_BUTTON(button) == SLOT_TUNIC_GORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON))
-        item = ITEM_TUNIC_GORON;
-    else if (DPAD_BUTTON(button) == SLOT_TUNIC_ZORA  && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA))
-        item = ITEM_TUNIC_ZORA;
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS_IRON  && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON))
-        item = ITEM_BOOTS_IRON;
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS_HOVER && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER))
-        item = ITEM_BOOTS_HOVER;
-    else item = ITEM_NONE;
-
-    if (item == ITEM_NONE)
-        return;
-
-    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + ((button+4) * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
-}
-
 u8 Interface_GetItemFromDpad(u8 button) {
-    if (gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_FIRE)
+    if (DPAD_BUTTON(button) == SLOT_ARROW_FIRE && gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_FIRE)
         return ITEM_BOW_FIRE;
-    else if (gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_ICE)
+    else if (DPAD_BUTTON(button) == SLOT_ARROW_ICE && gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_ICE)
         return ITEM_BOW_ICE;
-    else if (gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_LIGHT)
+    else if (DPAD_BUTTON(button) == SLOT_ARROW_LIGHT && gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_LIGHT)
         return ITEM_BOW_LIGHT;
     else if (DPAD_BUTTON(button) < SLOT_SWORDS)
         return gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)];
@@ -1899,7 +1870,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         }
         for (i=0; i<4; i++)
             if (DPAD_BUTTON(i) == SLOT_HOOKSHOT)
-                Interface_LoadItemIconDpad(play, i);
+                Interface_LoadItemIcon1(play, i+4);
         return ITEM_NONE;
     } else if (item == ITEM_DEKU_STICK) {
         if (gSaveContext.save.info.inventory.items[slot] == ITEM_NONE) {
@@ -2032,7 +2003,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         }
         for (i=0; i<4; i++)
             if (DPAD_BUTTON(i) == SLOT_OCARINA)
-                Interface_LoadItemIconDpad(play, i);
+                Interface_LoadItemIcon1(play, i+4);
         return ITEM_NONE;
     } else if (item == ITEM_MAGIC_BEAN) {
         if (gSaveContext.save.info.inventory.items[slot] == ITEM_NONE) {
@@ -2111,7 +2082,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         temp = SLOT(item);
 
         if ((item != ITEM_BOTTLE_MILK_FULL) && (item != ITEM_BOTTLE_RUTOS_LETTER)) {
-            s16 j;
+            u8 j;
             if (item == ITEM_MILK) {
                 item = ITEM_BOTTLE_MILK_FULL;
                 temp = SLOT(item);
@@ -2138,13 +2109,15 @@ u8 Item_Give(PlayState* play, u8 item) {
                         gSaveContext.buttonStatus[3] = BTN_ENABLED;
                     }
 
-                    for (j=0; j<4; j++)
-                        if (Interface_GetItemFromDpad(j) == temp + i) {
-                            Interface_LoadItemIconDpad(play, j);
-                            dpadStatus[j] = BTN_ENABLED;
-                        }
-                    
                     gSaveContext.save.info.inventory.items[temp + i] = item;
+
+                    for (j=0; j<4; j++)
+                        if (DPAD_BUTTON(j) == temp + i) {
+                            Interface_LoadItemIcon1(play, j+4);
+                            dpadStatus[j] = BTN_ENABLED;
+                            break;
+                        }
+
                     return ITEM_NONE;
                 }
             }
@@ -2346,7 +2319,7 @@ s32 Inventory_ReplaceItem(PlayState* play, u16 oldItem, u16 newItem) {
             }
             for (i=0; i<4; i++)
                 if (Interface_GetItemFromDpad(i) == oldItem)
-                    Interface_LoadItemIconDpad(play, i);                 
+                    Interface_LoadItemIcon1(play, i+4);                 
             return true;
         }
     }
@@ -2396,7 +2369,7 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
             }
         
         gSaveContext.save.info.inventory.items[DPAD_BUTTON(button-4)] = item;
-        Interface_LoadItemIconDpad(play, button-4);
+        Interface_LoadItemIcon1(play, button);
         dpadStatus[button-4] = BTN_ENABLED;
         
         return;
@@ -2414,7 +2387,7 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
     
     for (i=0; i<4; i++)
         if (Interface_GetItemFromDpad(i) == item)
-            Interface_LoadItemIconDpad(play, i);
+            Interface_LoadItemIcon1(play, i+4);
 
     Interface_LoadItemIcon1(play, button);
 
@@ -2441,7 +2414,7 @@ s32 Inventory_ConsumeFairy(PlayState* play) {
 
             for (j=0; j<4; j++)
                 if (DPAD_BUTTON(j) == bottleSlot) {
-                    Interface_LoadItemIconDpad(play, j);
+                    Interface_LoadItemIcon1(play, j+4);
                     break;
                 }
 
@@ -3206,7 +3179,7 @@ void Interface_DrawItemButtons(PlayState* play) {
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 2900);
 
     // D-Pad positions
-    dpad_x = R_MAGIC_METER_X + 6;
+    dpad_x = R_MAGIC_METER_X + 20;
     dpad_y = ( (gSaveContext.save.info.playerData.healthCapacity > 0xA0) ? R_MAGIC_METER_Y_LOWER : R_MAGIC_METER_Y_HIGHER) + 15;
     if (gSaveContext.save.info.playerData.magicLevel != 0)
         dpad_y += 15;
@@ -3392,28 +3365,31 @@ void Interface_DrawItemIconTexture(PlayState* play, void* texture, s16 button) {
     u8  width;
     u8  item;
     s8  offset = 0;
-    Player* player = GET_PLAYER(play);
     
     if (button < 4) {
         x     = R_ITEM_ICON_X(button);
         y     = R_ITEM_ICON_Y(button);
         dd    = R_ITEM_ICON_DD(button);
         width = R_ITEM_ICON_WIDTH(button);
+        
+        if ((gSaveContext.save.info.equips.buttonItems[button] == ITEM_SWORDS && gSaveContext.save.info.equips.buttonItems[0] == ITEM_NONE) || (gSaveContext.save.info.equips.buttonItems[button] == ITEM_SHIELDS && SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD) == PLAYER_SHIELD_NONE)))
+            return;
     }
     else {
+        Player* player = GET_PLAYER(play);
         dd    = 1400;
         width = 12;
         
-        switch (button) {
-            case 4:
+        switch (button-4) {
+            case 0:
                 x = D_UP_BUTTON_X;
                 y = D_UP_BUTTON_Y;
                 break;
-            case 5:
+            case 1:
                 x = D_RIGHT_BUTTON_X;
                 y = D_RIGHT_BUTTON_Y;
                 break;
-            case 6:
+            case 2:
                 x = D_DOWN_BUTTON_X;
                 y = D_DOWN_BUTTON_Y;
                 break;
@@ -3429,6 +3405,9 @@ void Interface_DrawItemIconTexture(PlayState* play, void* texture, s16 button) {
             width +=  3;
             offset = -1;
         }
+        
+        if ((item == ITEM_SWORDS && gSaveContext.save.info.equips.buttonItems[0] == ITEM_NONE) || (item == ITEM_SHIELDS && SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD) == PLAYER_SHIELD_NONE)))
+            return;
     }
 
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 3079);
@@ -3498,16 +3477,16 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
         }
         else {
             u8 x, y;
-            switch (button) {
-                case 4:
+            switch (button-4) {
+                case 0:
                     x = D_UP_BUTTON_X + 1;
                     y = D_UP_BUTTON_Y + 8;
                     break;
-                case 5:
+                case 1:
                     x = D_RIGHT_BUTTON_X + 1;
                     y = D_RIGHT_BUTTON_Y + 8;
                     break;
-                case 6:
+                case 2:
                     x = D_DOWN_BUTTON_X + 1;
                     y = D_DOWN_BUTTON_Y + 8;
                     break;
@@ -3518,8 +3497,8 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
             }
 
             if (i != 0)
-                OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8, x, y, 6, 6, 1 << 11, 1 << 11);
-            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * ammo)), 8, 8, x + 3, y, 6, 6, 1 << 11, 1 << 11);
+                OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8, x, y, 4, 4, 1 << 11, 1 << 11);
+            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * ammo)), 8, 8, x + 3, y, 4, 4, 1 << 11, 1 << 11);
         }
     }
 
@@ -3862,7 +3841,7 @@ void Interface_Draw(PlayState* play) {
         gDPPipeSync(OVERLAY_DISP++);
 
         // C-Left Button Icon & Ammo Count
-        if (gSaveContext.save.info.equips.buttonItems[1] < 0xF0 || (gSaveContext.save.info.equips.buttonItems[1] == ITEM_SWORDS && player->currentSwordItemId == -1) || (gSaveContext.save.info.equips.buttonItems[1] == ITEM_SHIELDS && player->currentShield == PLAYER_SHIELD_NONE)) {
+        if (gSaveContext.save.info.equips.buttonItems[1] < 0xF0) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cLeftAlpha);
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
             Interface_DrawItemIconTexture(play, interfaceCtx->iconItemSegment + 0x1000, 1);
@@ -3875,7 +3854,7 @@ void Interface_Draw(PlayState* play) {
         gDPPipeSync(OVERLAY_DISP++);
 
         // C-Down Button Icon & Ammo Count
-        if (gSaveContext.save.info.equips.buttonItems[2] < 0xF0 || (gSaveContext.save.info.equips.buttonItems[2] == ITEM_SWORDS && player->currentSwordItemId == -1) || (gSaveContext.save.info.equips.buttonItems[2] == ITEM_SHIELDS && player->currentShield == PLAYER_SHIELD_NONE)) {
+        if (gSaveContext.save.info.equips.buttonItems[2] < 0xF0) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cDownAlpha);
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
             Interface_DrawItemIconTexture(play, interfaceCtx->iconItemSegment + 0x2000, 2);
@@ -3888,7 +3867,7 @@ void Interface_Draw(PlayState* play) {
         gDPPipeSync(OVERLAY_DISP++);
 
         // C-Right Button Icon & Ammo Count
-        if (gSaveContext.save.info.equips.buttonItems[3] < 0xF0 || (gSaveContext.save.info.equips.buttonItems[3] == ITEM_SWORDS && player->currentSwordItemId == -1) || (gSaveContext.save.info.equips.buttonItems[3] == ITEM_SHIELDS && player->currentShield == PLAYER_SHIELD_NONE)) {
+        if (gSaveContext.save.info.equips.buttonItems[3] < 0xF0) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cRightAlpha);
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
             Interface_DrawItemIconTexture(play, interfaceCtx->iconItemSegment + 0x3000, 3);
@@ -3899,7 +3878,7 @@ void Interface_Draw(PlayState* play) {
         }
 
         for (svar1=0; svar1<4; svar1++) {
-            if (Interface_GetItemFromDpad(svar1) >= 0xF0 || (Interface_GetItemFromDpad(svar1) == ITEM_SWORDS && player->currentSwordItemId == -1) || (Interface_GetItemFromDpad(svar1) == ITEM_SHIELDS && player->currentShield == PLAYER_SHIELD_NONE))
+            if (Interface_GetItemFromDpad(svar1) >= 0xF0)
                 continue;
 
             // D-Pad Button Icon & Ammo Count
@@ -4093,7 +4072,7 @@ void Interface_Draw(PlayState* play) {
                     }
                     for (svar2=0; svar2<4; svar2++)
                         if (Interface_GetItemFromDpad(svar2) == gSpoilingItemReverts[svar1])
-                            Interface_LoadItemIconDpad(play, svar2);
+                            Interface_LoadItemIcon1(play, svar2+4);
                 }
             }
         }
@@ -4941,11 +4920,14 @@ void Interface_Update(PlayState* play) {
 void Interface_ChangeDpadSet(PlayState* play) {
     u8 i;
 
-    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R) && !pressed_z && gSaveContext.minigameState == 0 && !IS_CUTSCENE_LAYER) {
+    if (play->pauseCtx.debugState != 0 || gSaveContext.gameMode != GAMEMODE_NORMAL)
+        return;
+
+    if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R) && !pressed_z && !IS_CUTSCENE_LAYER && gSaveContext.minigameState == 0) {
         Audio_PlaySfxGeneral(!gSaveContext.save.info.playerData.dpadDualSet ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         gSaveContext.save.info.playerData.dpadDualSet ^= 1;
         for (i=0; i<4; i++) {
-            Interface_LoadItemIconDpad(play, i);
+            Interface_LoadItemIcon1(play, i+4);
             if (play->pauseCtx.state == PAUSE_STATE_OFF) {
                 dpadStatus[i] = BTN_ENABLED;
                 switchedDualSet = false;
@@ -4955,8 +4937,8 @@ void Interface_ChangeDpadSet(PlayState* play) {
         gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode;
     }
 
-    if (!IS_PAUSED(&play->pauseCtx) && &play->pauseCtx.debugState == 0 && CHECK_BTN_ALL(play->state.input[0].press.button, BTN_Z))
-        pressed_z = 1;
+    if (!IS_PAUSED(&play->pauseCtx) && CHECK_BTN_ALL(play->state.input[0].press.button, BTN_Z))
+        pressed_z = true;
     if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L))
-        pressed_z = 0;
+        pressed_z = false;
 }

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -194,6 +194,10 @@ static Gfx sSetupDL_80125A60[] = {
     gsSPEndDisplayList(),
 };
 
+u8 Interface_IsEquipmentItem(u8 item) {
+    return ((item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER);
+}
+
 // original name: "alpha_change"
 void Interface_ChangeHudVisibilityMode(u16 hudVisibilityMode) {
     if (hudVisibilityMode != gSaveContext.hudVisibilityMode) {
@@ -706,7 +710,6 @@ void func_80083108(PlayState* play) {
     MessageContext* msgCtx = &play->msgCtx;
     s16 i;
     s16 sp28 = false;
-    u8 item;
 
     if ((gSaveContext.save.cutsceneIndex < 0xFFF0) ||
         ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == 0xFFF0))) {
@@ -820,31 +823,31 @@ void func_80083108(PlayState* play) {
                 gSaveContext.buttonStatus[0] = BTN_DISABLED;
 
                 for (i = 1; i < 4; i++) {
-                    item = gSaveContext.save.info.equips.buttonItems[i];
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
-                        if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT) && !Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i])) {
                             if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
                                 sp28 = true;
                             }
 
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
                         } else {
                             if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
                                 sp28 = true;
                             }
 
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                        }
-                    } else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
-                        if ((item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH) || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
-                                sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         }
-                        else {
+                    } else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i]  < ITEM_MASK_KEATON || gSaveContext.save.info.equips.buttonItems[i]  > ITEM_MASK_TRUTH) && !Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i])) {
                             if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
                                 sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                        }
+                        else {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         }
                     } else {
                         if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
@@ -855,28 +858,27 @@ void func_80083108(PlayState* play) {
                     }
                 }
                 for (i=0; i<4; i++) {
-                    item = Interface_GetItemFromDpad(i);
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
-                        if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
-                            if (dpadStatus[i] == BTN_DISABLED)
-                                sp28 = true;
-                            dpadStatus[i] = BTN_ENABLED;
-                        } else {
+                        if (Interface_GetItemFromDpad(i) != ITEM_HOOKSHOT && Interface_GetItemFromDpad(i) != ITEM_LONGSHOT && !Interface_IsEquipmentItem(Interface_GetItemFromDpad(i))) {
                             if (dpadStatus[i] == BTN_ENABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_DISABLED;
+                        } else {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
                         }
                     }
                     else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
-                        if ((item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH) || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
-                            if (dpadStatus[i] == BTN_DISABLED)
-                                sp28 = true;
-                            dpadStatus[i] = BTN_ENABLED;
-                        }
-                        else {
+                        if (((Interface_GetItemFromDpad(i) < ITEM_MASK_KEATON || Interface_GetItemFromDpad(i) > ITEM_MASK_TRUTH)) && !Interface_IsEquipmentItem(Interface_GetItemFromDpad(i))) {
                             if (dpadStatus[i] == BTN_ENABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_DISABLED;
+                        }
+                        else {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
                         }
                     }
                     else {
@@ -1029,7 +1031,7 @@ void func_80083108(PlayState* play) {
                         }
                     }
                     for (i=0; i<4; i++)
-                        if (Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY || Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE) {
+                        if (Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY && Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE) {
                             if (dpadStatus[i] == BTN_ENABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_DISABLED;
@@ -1046,7 +1048,7 @@ void func_80083108(PlayState* play) {
                         }
                     }
                     for (i=0; i<4; i++)
-                        if (Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY || Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE) {
+                        if (Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY && Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE) {
                             if (dpadStatus[i] == BTN_DISABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_ENABLED;
@@ -1232,26 +1234,34 @@ void func_80083108(PlayState* play) {
                         }
                 }
 
-                if (interfaceCtx->restrictions.all) {
-                    for (i=1; i<4; i++) {
-                        item = gSaveContext.save.info.equips.buttonItems[i];
-                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
-                            if (play->sceneId != SCENE_TREASURE_BOX_SHOP || gSaveContext.save.info.equips.buttonItems[i] != ITEM_LENS_OF_TRUTH) {
-                                if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
+                if (interfaceCtx->restrictions.all != 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME) &&
+                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
+                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) &&
+                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
+                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK)) &&
+                            !(Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i]))) {
+                            if ((play->sceneId != SCENE_TREASURE_BOX_SHOP) ||
+                                (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LENS_OF_TRUTH)) {
+                                if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
                                     sp28 = true;
+                                }
+
                                 gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                            }
-                            else {
-                                if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
+                            } else {
+                                if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
                                     sp28 = true;
+                                }
+
                                 gSaveContext.buttonStatus[i] = BTN_ENABLED;
                             }
                         }
                     }
-                    for (i=0; i<4; i++) {
-                        item = Interface_GetItemFromDpad(i);
-                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
-                            if (play->sceneId != SCENE_TREASURE_BOX_SHOP || item != ITEM_LENS_OF_TRUTH) {
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) != ITEM_OCARINA_FAIRY && Interface_GetItemFromDpad(i) != ITEM_OCARINA_OF_TIME && !(Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY && Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE) && !(Interface_GetItemFromDpad(i) >= ITEM_WEIRD_EGG && Interface_GetItemFromDpad(i) <= ITEM_CLAIM_CHECK) && !Interface_IsEquipmentItem(Interface_GetItemFromDpad(i))) {
+                            if (play->sceneId != SCENE_TREASURE_BOX_SHOP || Interface_GetItemFromDpad(i) != ITEM_LENS_OF_TRUTH) {
                                 if (dpadStatus[i] == BTN_ENABLED)
                                     sp28 = true;
                                 dpadStatus[i] = BTN_DISABLED;
@@ -1262,25 +1272,35 @@ void func_80083108(PlayState* play) {
                                 dpadStatus[i] = BTN_ENABLED;
                             }
                         }
-                    }
-                }
-                else if (!interfaceCtx->restrictions.all) {
-                    for (i=1; i<4; i++) {
-                        item = gSaveContext.save.info.equips.buttonItems[i];
-                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
+                } else if (interfaceCtx->restrictions.all == 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_DINS_FIRE) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_FARORES_WIND) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_NAYRUS_LOVE) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME) &&
+                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
+                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) &&
+                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
+                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK)) &&
+                            !(Interface_IsEquipmentItem(gSaveContext.save.info.equips.buttonItems[i]))) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
                                 sp28 = true;
+                            }
+
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         }
                     }
-                    for (i=0; i<4; i++) {
-                        item = Interface_GetItemFromDpad(i);
-                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) && !(item >= ITEM_SWORDS && item <= ITEM_BOOTS) && item != ITEM_TUNIC_GORON && item != ITEM_TUNIC_ZORA && item != ITEM_BOOTS_IRON && item != ITEM_BOOTS_HOVER) {
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) != ITEM_DINS_FIRE     && Interface_GetItemFromDpad(i) != ITEM_HOOKSHOT         &&   Interface_GetItemFromDpad(i) != ITEM_LONGSHOT     && Interface_GetItemFromDpad(i) != ITEM_FARORES_WIND && Interface_GetItemFromDpad(i) != ITEM_NAYRUS_LOVE &&
+                            Interface_GetItemFromDpad(i) != ITEM_OCARINA_FAIRY && Interface_GetItemFromDpad(i) != ITEM_OCARINA_OF_TIME  && !(Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY && Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE)  &&
+                          !(Interface_GetItemFromDpad(i) >= ITEM_WEIRD_EGG     && Interface_GetItemFromDpad(i) <= ITEM_CLAIM_CHECK)     &&  !Interface_IsEquipmentItem(Interface_GetItemFromDpad(i))) {
                             if (dpadStatus[i] == BTN_DISABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_ENABLED;
                         }
-                    }
                 }
             }
         }
@@ -1552,7 +1572,7 @@ void Interface_LoadItemIconDpad(PlayState* play, u8 button) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     Player* player = GET_PLAYER(play);
     u8 item;
-    
+
     if (DPAD_BUTTON(button) < SLOT_SWORDS)
         item = DPAD_BUTTON_ITEM(button);
     else if (DPAD_BUTTON(button) == SLOT_SWORDS)
@@ -1573,9 +1593,7 @@ void Interface_LoadItemIconDpad(PlayState* play, u8 button) {
         item = ITEM_BOOTS_HOVER;
     else item = ITEM_NONE;
 
-    osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
     DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + ((button+4) * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
-    osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
 
 u8 Interface_GetArrowFromDpad(u8 button) {

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1590,12 +1590,14 @@ void Interface_LoadItemIcon2(PlayState* play, u16 button) {
 }
 
 u8 Interface_GetItemFromDpad(u8 button) {
-    if (DPAD_BUTTON(button) == SLOT_ARROW_FIRE && gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_FIRE)
-        return ITEM_BOW_FIRE;
-    else if (DPAD_BUTTON(button) == SLOT_ARROW_ICE && gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_ICE)
-        return ITEM_BOW_ICE;
-    else if (DPAD_BUTTON(button) == SLOT_ARROW_LIGHT && gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_LIGHT)
-        return ITEM_BOW_LIGHT;
+    if (DPAD_BUTTON(button) == SLOT_ARROW_FIRE)
+        return (gSaveContext.save.info.inventory.items[SLOT_ARROW_FIRE]  == ITEM_ARROW_FIRE)  ? ITEM_BOW_FIRE  : ITEM_NONE;
+    else if (DPAD_BUTTON(button) == SLOT_ARROW_ICE)
+        return (gSaveContext.save.info.inventory.items[SLOT_ARROW_ICE]   == ITEM_ARROW_ICE)   ? ITEM_BOW_ICE   : ITEM_NONE;
+    else if (DPAD_BUTTON(button) == SLOT_ARROW_LIGHT)
+        return( gSaveContext.save.info.inventory.items[SLOT_ARROW_LIGHT] == ITEM_ARROW_LIGHT) ? ITEM_BOW_LIGHT : ITEM_NONE;
+    else if (DPAD_BUTTON(button) == SLOT_TRADE_CHILD)
+        return (gSaveContext.save.info.inventory.items[SLOT_TRADE_CHILD] >= ITEM_WEIRD_EGG && gSaveContext.save.info.inventory.items[SLOT_TRADE_CHILD] <= ITEM_MASK_TRUTH) ? gSaveContext.save.info.inventory.items[SLOT_TRADE_CHILD] : ITEM_NONE;
     else if (DPAD_BUTTON(button) < SLOT_SWORDS)
         return gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)];
     else if (DPAD_BUTTON(button) == SLOT_SWORDS)
@@ -3183,7 +3185,7 @@ void Interface_DrawItemButtons(PlayState* play) {
     dpad_y = ( (gSaveContext.save.info.playerData.healthCapacity > 0xA0) ? R_MAGIC_METER_Y_LOWER : R_MAGIC_METER_Y_HIGHER) + 15;
     if (gSaveContext.save.info.playerData.magicLevel != 0)
         dpad_y += 15;
-    if ( (gSaveContext.timerState == TIMER_STATE_ENV_HAZARD_TICK || gSaveContext.timerState == TIMER_STATE_DOWN_TICK || gSaveContext.timerState == TIMER_STATE_UP_TICK || gSaveContext.timerState == TIMER_STATE_UP_FREEZE) && pauseCtx->state == PAUSE_STATE_OFF) {
+    if (IS_ACTIVE_TIMER && pauseCtx->state == PAUSE_STATE_OFF) {
         dpad_y += 15;
         if (gSaveContext.save.info.playerData.magicLevel == 0)
             dpad_y = ( (gSaveContext.save.info.playerData.healthCapacity > 0xA0) ? R_MAGIC_METER_Y_LOWER : R_MAGIC_METER_Y_HIGHER) + 45;

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -706,6 +706,7 @@ void func_80083108(PlayState* play) {
     MessageContext* msgCtx = &play->msgCtx;
     s16 i;
     s16 sp28 = false;
+    u8 item;
 
     if ((gSaveContext.save.cutsceneIndex < 0xFFF0) ||
         ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == 0xFFF0))) {
@@ -819,31 +820,31 @@ void func_80083108(PlayState* play) {
                 gSaveContext.buttonStatus[0] = BTN_DISABLED;
 
                 for (i = 1; i < 4; i++) {
+                    item = gSaveContext.save.info.equips.buttonItems[i];
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT)) {
+                        if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
                             if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
                                 sp28 = true;
                             }
 
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         } else {
                             if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
                                 sp28 = true;
                             }
 
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
-                        }
-                    } else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
-                        if (gSaveContext.save.info.equips.buttonItems[i] < ITEM_MASK_KEATON || gSaveContext.save.info.equips.buttonItems[i] > ITEM_MASK_TRUTH) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
-                                sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_DISABLED;
                         }
-                        else {
+                    } else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
+                        if ((item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH) || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
                             if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
                                 sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
+                        else {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
                         }
                     } else {
                         if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
@@ -854,27 +855,28 @@ void func_80083108(PlayState* play) {
                     }
                 }
                 for (i=0; i<4; i++) {
+                    item = Interface_GetItemFromDpad(i);
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
-                        if (DPAD_BUTTON_ITEM(i) != ITEM_HOOKSHOT && DPAD_BUTTON_ITEM(i) != ITEM_LONGSHOT) {
-                            if (dpadStatus[i] == BTN_ENABLED)
-                                sp28 = true;
-                            dpadStatus[i] = BTN_DISABLED;
-                        } else {
+                        if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
                             if (dpadStatus[i] == BTN_DISABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_ENABLED;
+                        } else {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
                         }
                     }
                     else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
-                        if (DPAD_BUTTON_ITEM(i) < ITEM_MASK_KEATON || DPAD_BUTTON_ITEM(i) > ITEM_MASK_TRUTH) {
-                            if (dpadStatus[i] == BTN_ENABLED)
-                                sp28 = true;
-                            dpadStatus[i] = BTN_DISABLED;
-                        }
-                        else {
+                        if ((item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH) || (item >= ITEM_SWORDS && item <= ITEM_BOOTS) || item == ITEM_TUNIC_GORON || item == ITEM_TUNIC_ZORA || item == ITEM_BOOTS_IRON || item == ITEM_BOOTS_HOVER) {
                             if (dpadStatus[i] == BTN_DISABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_ENABLED;
+                        }
+                        else {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
                         }
                     }
                     else {
@@ -1015,112 +1017,219 @@ void func_80083108(PlayState* play) {
                     }
                 }
 
-                status = !interfaceCtx->restrictions.bottles;
-                for (i=1; i<4; i++) {
-                    item = gSaveContext.save.info.equips.buttonItems[i];
-                    if (item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) {
-                        if (gSaveContext.buttonStatus[i] != status)
-                            sp28 = true;
-                        gSaveContext.buttonStatus[i] = status;
+                if (interfaceCtx->restrictions.bottles != 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                        }
                     }
-                }
-                for (i=0; i<4; i++) {
-                    item = Interface_GetItemFromDpad(i);
-                    if (item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) {
-                        if (dpadStatus[i] != status)
-                            sp28 = true;
-                        dpadStatus[i] = status;
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY || Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        }
+                } else if (interfaceCtx->restrictions.bottles == 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
                     }
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) >= ITEM_BOTTLE_EMPTY || Interface_GetItemFromDpad(i) <= ITEM_BOTTLE_POE) {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
                 }
 
-                status = !interfaceCtx->restrictions.tradeItems;
-                for (i=1; i<4; i++) {
-                    item = gSaveContext.save.info.equips.buttonItems[i];
-                    if (item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) {
-                        if (gSaveContext.buttonStatus[i] != status)
-                            sp28 = true;
-                        gSaveContext.buttonStatus[i] = status;
+                if (interfaceCtx->restrictions.tradeItems != 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                        }
                     }
-                }
-                for (i=0; i<4; i++) {
-                    item = Interface_GetItemFromDpad(i);
-                    if (item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) {
-                        if (dpadStatus[i] != status)
-                            sp28 = true;
-                        dpadStatus[i] = status;
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) >= ITEM_WEIRD_EGG || Interface_GetItemFromDpad(i) <= ITEM_CLAIM_CHECK) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        }
+                } else if (interfaceCtx->restrictions.tradeItems == 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
+                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
                     }
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) >= ITEM_WEIRD_EGG && Interface_GetItemFromDpad(i) <= ITEM_CLAIM_CHECK) {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
                 }
 
-                status = !interfaceCtx->restrictions.hookshot;
-                for (i=1; i<4; i++) {
-                    item = gSaveContext.save.info.equips.buttonItems[i];
-                    if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT) {
-                        if (gSaveContext.buttonStatus[i] != status)
-                            sp28 = true;
-                        gSaveContext.buttonStatus[i] = status;
+                if (interfaceCtx->restrictions.hookshot != 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_HOOKSHOT) ||
+                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_LONGSHOT)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                        }
                     }
-                }
-                for (i=0; i<4; i++) {
-                    item = Interface_GetItemFromDpad(i);
-                    if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT) {
-                        if (dpadStatus[i] != status)
-                            sp28 = true;
-                        dpadStatus[i] = status;
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_HOOKSHOT || Interface_GetItemFromDpad(i) == ITEM_LONGSHOT) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        }
+                } else if (interfaceCtx->restrictions.hookshot == 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_HOOKSHOT) ||
+                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_LONGSHOT)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
                     }
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_HOOKSHOT || Interface_GetItemFromDpad(i) == ITEM_LONGSHOT) {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
                 }
 
-                status = !interfaceCtx->restrictions.ocarina;
-                for (i=1; i<4; i++) {
-                    item = gSaveContext.save.info.equips.buttonItems[i];
-                    if (item == ITEM_OCARINA_FAIRY || item == ITEM_OCARINA_OF_TIME) {
-                        if (gSaveContext.buttonStatus[i] != status)
-                            sp28 = true;
-                        gSaveContext.buttonStatus[i] = status;
+                if (interfaceCtx->restrictions.ocarina != 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_FAIRY) ||
+                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_OF_TIME)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                        }
                     }
-                }
-                for (i=0; i<4; i++) {
-                    item = Interface_GetItemFromDpad(i);
-                    if (item == ITEM_OCARINA_FAIRY || item == ITEM_OCARINA_OF_TIME) {
-                        if (dpadStatus[i] != status)
-                            sp28 = true;
-                        dpadStatus[i] = status;
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_OCARINA_FAIRY || Interface_GetItemFromDpad(i) == ITEM_OCARINA_OF_TIME) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        }
+                } else if (interfaceCtx->restrictions.ocarina == 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_FAIRY) ||
+                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_OF_TIME)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
                     }
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_OCARINA_FAIRY || Interface_GetItemFromDpad(i) == ITEM_OCARINA_OF_TIME) {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
                 }
 
-                status = !interfaceCtx->restrictions.farores;
-                for (i=1; i<4; i++) {
-                    item = gSaveContext.save.info.equips.buttonItems[i];
-                    if (item == ITEM_FARORES_WIND) {
-                        if (gSaveContext.buttonStatus[i] != status)
-                            sp28 = true;
-                        gSaveContext.buttonStatus[i] = status;
+                if (interfaceCtx->restrictions.farores != 0) {
+                    for (i = 1; i < 4; i++) {
+                        if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_FARORES_WIND) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                            PRINTF("***(i=%d)***  ", i);
+                        }
                     }
-                }
-                for (i=0; i<4; i++) {
-                    item = Interface_GetItemFromDpad(i);
-                    if (item == ITEM_FARORES_WIND) {
-                        if (dpadStatus[i] != status)
-                            sp28 = true;
-                        dpadStatus[i] = status;
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_FARORES_WIND) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        }
+                } else if (interfaceCtx->restrictions.farores == 0) {
+                    for (i = 1; i < 4; i++) {
+                        if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_FARORES_WIND) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
                     }
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_FARORES_WIND) {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
                 }
 
-                status = !interfaceCtx->restrictions.dinsNayrus;
-                for (i=1; i<4; i++) {
-                    item = gSaveContext.save.info.equips.buttonItems[i];
-                    if (item == ITEM_DINS_FIRE || item == ITEM_NAYRUS_LOVE) {
-                        if (gSaveContext.buttonStatus[i] != status)
-                            sp28 = true;
-                        gSaveContext.buttonStatus[i] = status;
+                if (interfaceCtx->restrictions.dinsNayrus != 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_DINS_FIRE) ||
+                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_NAYRUS_LOVE)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                        }
                     }
-                }
-                for (i=0; i<4; i++) {
-                    item = Interface_GetItemFromDpad(i);
-                    if (item == ITEM_DINS_FIRE || item == ITEM_NAYRUS_LOVE) {
-                        if (dpadStatus[i] != status)
-                            sp28 = true;
-                        dpadStatus[i] = status;
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_DINS_FIRE || Interface_GetItemFromDpad(i) == ITEM_NAYRUS_LOVE) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        }
+                } else if (interfaceCtx->restrictions.dinsNayrus == 0) {
+                    for (i = 1; i < 4; i++) {
+                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_DINS_FIRE) ||
+                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_NAYRUS_LOVE)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                                sp28 = true;
+                            }
+
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
                     }
+                    for (i=0; i<4; i++)
+                        if (Interface_GetItemFromDpad(i) == ITEM_DINS_FIRE || Interface_GetItemFromDpad(i) == ITEM_NAYRUS_LOVE) {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
                 }
 
                 if (interfaceCtx->restrictions.all) {

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -3264,6 +3264,10 @@ void Interface_DrawItemIconTexture(PlayState* play, void* texture, s16 button) {
         }
         
         item = Interface_GetItemFromDpad(button-4);
+        if ( (DPAD_BUTTON(button-4) == SLOT_TUNIC_GORON && !CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON)) || (DPAD_BUTTON(button-4) == SLOT_TUNIC_ZORA  && !CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA)) ||
+             (DPAD_BUTTON(button-4) == SLOT_BOOTS_IRON  && !CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON))  || (DPAD_BUTTON(button-4) == SLOT_BOOTS_HOVER && !CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER)) )
+            return;
+        
         if ( (item == ITEM_TUNIC_GORON && player->currentTunic == 1) || (item == ITEM_TUNIC_ZORA && player->currentTunic == 2) || (item == ITEM_BOOTS_IRON && player->currentBoots == 1) || (item == ITEM_BOOTS_HOVER && player->currentBoots == 2) || (item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH && player->currentMask == item - ITEM_MASK_KEATON + 1) ) {
             dd    *=  0.8;
             width +=  3;
@@ -3739,17 +3743,16 @@ void Interface_Draw(PlayState* play) {
         }
 
         for (svar1=0; svar1<4; svar1++) {
-            gDPPipeSync(OVERLAY_DISP++);
-           
+            if (Interface_GetItemFromDpad(svar1) >= 0xF0)
+                continue;
+
             // D-Pad Button Icon & Ammo Count
-            if (DPAD_BUTTON_ITEM(svar1) < 0xF0 || Interface_GetItemFromDpad(svar1) < 0xF0)  {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[svar1+1]);
-                gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
-                Interface_DrawItemIconTexture(play, interfaceCtx->iconItemSegment + 0x4000 + (0x1000*svar1), 4+svar1);
-                gDPPipeSync(OVERLAY_DISP++);
-                gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
-                Interface_DrawAmmoCount(play, 4+svar1,  dpadAlphas[svar1+1]);
-            }
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[svar1+1]);
+            gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
+            Interface_DrawItemIconTexture(play, interfaceCtx->iconItemSegment + 0x4000 + (0x1000*svar1), 4+svar1);
+            gDPPipeSync(OVERLAY_DISP++);
+            gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+            Interface_DrawAmmoCount(play, 4+svar1,  dpadAlphas[svar1+1]);
         }
 
         // A Button

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -155,6 +155,7 @@ static s16 sMagicBorderB = 255;
 
 bool dpadStatus[] = { BTN_ENABLED, BTN_ENABLED, BTN_ENABLED, BTN_ENABLED };
 u8 dpadAlphas[] = { 0, 0, 0, 0, 0 };
+bool switchedDualSet = false;
 static bool pressed_z = false;
 static u16 dpad_x;
 static u16 dpad_y;
@@ -4916,16 +4917,21 @@ void Interface_Update(PlayState* play) {
 
 void Interface_ChangeDpadSet(PlayState* play) {
     u8 i;
-    
+
     if (CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_L) && CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_R) && !pressed_z && gSaveContext.minigameState == 0 && !IS_CUTSCENE_LAYER) {
         Audio_PlaySfxGeneral(!gSaveContext.save.info.playerData.dpadDualSet ? NA_SE_SY_CAMERA_ZOOM_UP : NA_SE_SY_CAMERA_ZOOM_DOWN, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         gSaveContext.save.info.playerData.dpadDualSet ^= 1;
         for (i=0; i<4; i++) {
             Interface_LoadItemIconDpad(play, i);
-            dpadStatus[i] = BTN_ENABLED;
+            if (play->pauseCtx.state == PAUSE_STATE_OFF) {
+                dpadStatus[i] = BTN_ENABLED;
+                switchedDualSet = false;
+            }
+            else switchedDualSet = true;
         }
         gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode;
     }
+
     if (!IS_PAUSED(&play->pauseCtx) && &play->pauseCtx.debugState == 0 && CHECK_BTN_ALL(play->state.input[0].press.button, BTN_Z))
         pressed_z = 1;
     if (CHECK_BTN_ALL(play->state.input[0].rel.button, BTN_L))

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1243,6 +1243,9 @@ void Interface_SetSceneRestrictions(PlayState* play) {
         }
         i++;
     } while (sRestrictionFlags[i].sceneId != 0xFF);
+    
+    if (interfaceCtx->restrictions.tradeItems == 0)
+        GET_PLAYER(play)->currentMask = GET_MASK_AGE();
 }
 
 Gfx* Gfx_TextureIA8(Gfx* displayListHead, void* texture, s16 textureWidth, s16 textureHeight, s16 rectLeft, s16 rectTop,

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -708,6 +708,8 @@ void func_80083108(PlayState* play) {
     MessageContext* msgCtx = &play->msgCtx;
     s16 i;
     s16 sp28 = false;
+    u8 status;
+    u8 item;
 
     if ((gSaveContext.save.cutsceneIndex < 0xFFF0) ||
         ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == 0xFFF0))) {
@@ -816,28 +818,64 @@ void func_80083108(PlayState* play) {
 
                 gSaveContext.buttonStatus[0] = BTN_DISABLED;
 
-                for (i = 1; i < 4; i++) {
+                for (i=1; i<4; i++) {
                     if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                        if (gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT && gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
                                 sp28 = true;
-                            }
-
                             gSaveContext.buttonStatus[i] = BTN_DISABLED;
                         } else {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
                                 sp28 = true;
-                            }
-
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
                         }
-                    } else {
-                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
-                            sp28 = true;
+                    }
+                    else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
+                        if (gSaveContext.save.info.equips.buttonItems[i] < ITEM_MASK_KEATON || gSaveContext.save.info.equips.buttonItems[i] > ITEM_MASK_TRUTH) {
+                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
                         }
-
+                        else {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
+                    }
+                    else {
+                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
+                            sp28 = true;
                         gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                    }
+                }
+                for (i=0; i<4; i++) {
+                    if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
+                        if (DPAD_BUTTON_ITEM(i) != ITEM_HOOKSHOT && DPAD_BUTTON_ITEM(i) != ITEM_LONGSHOT) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        } else {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
+                    }
+                    else if (Player_GetEnvironmentalHazard(play) == PLAYER_ENV_HAZARD_SWIMMING) {
+                        if (DPAD_BUTTON_ITEM(i) < ITEM_MASK_KEATON || DPAD_BUTTON_ITEM(i) > ITEM_MASK_TRUTH) {
+                            if (dpadStatus[i] == BTN_ENABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_DISABLED;
+                        }
+                        else {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
+                        }
+                    }
+                    else {
+                        if (dpadStatus[i] == BTN_ENABLED)
+                            sp28 = true;
+                        dpadStatus[i] = BTN_DISABLED;
                     }
                 }
 
@@ -889,20 +927,28 @@ void func_80083108(PlayState* play) {
                     sp28 = false;
                 }
 
-                for (i = 1; i < 4; i++) {
-                    if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY) &&
-                        (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME)) {
-                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+                for (i=1; i<4; i++) {
+                    if (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY && gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME) {
+                        if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
                             sp28 = true;
-                        }
-
                         gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                    } else {
-                        if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                    }
+                    else {
+                        if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
                             sp28 = true;
-                        }
-
                         gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                    }
+                }
+                for (i=0; i<4; i++) {
+                    if (DPAD_BUTTON_ITEM(i) != ITEM_OCARINA_FAIRY && DPAD_BUTTON_ITEM(i) != ITEM_OCARINA_OF_TIME) {
+                        if (dpadStatus[i] == BTN_ENABLED)
+                            sp28 = true;
+                        dpadStatus[i] = BTN_DISABLED;
+                    }
+                    else {
+                        if (dpadStatus[i] == BTN_DISABLED)
+                            sp28 = true;
+                        dpadStatus[i] = BTN_ENABLED;
                     }
                 }
 
@@ -959,191 +1005,161 @@ void func_80083108(PlayState* play) {
                     }
                 }
 
-                if (interfaceCtx->restrictions.bottles != 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                        }
-                    }
-                } else if (interfaceCtx->restrictions.bottles == 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
-                        }
+                status = !interfaceCtx->restrictions.bottles;
+                for (i=1; i<4; i++) {
+                    item = gSaveContext.save.info.equips.buttonItems[i];
+                    if (item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) {
+                        if (gSaveContext.buttonStatus[i] != status)
+                            sp28 = true;
+                        gSaveContext.buttonStatus[i] = status;
                     }
                 }
-
-                if (interfaceCtx->restrictions.tradeItems != 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                        }
-                    }
-                } else if (interfaceCtx->restrictions.tradeItems == 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
-                        }
+                for (i=0; i<4; i++) {
+                    item = Interface_GetItemFromDpad(i);
+                    if (item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) {
+                        if (dpadStatus[i] != status)
+                            sp28 = true;
+                        dpadStatus[i] = status;
                     }
                 }
-
-                if (interfaceCtx->restrictions.hookshot != 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_HOOKSHOT) ||
-                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_LONGSHOT)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                        }
-                    }
-                } else if (interfaceCtx->restrictions.hookshot == 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_HOOKSHOT) ||
-                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_LONGSHOT)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
-                        }
+            
+                status = !interfaceCtx->restrictions.tradeItems;
+                for (i=1; i<4; i++) {
+                    item = gSaveContext.save.info.equips.buttonItems[i];
+                    if (item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) {
+                        if (gSaveContext.buttonStatus[i] != status)
+                            sp28 = true;
+                        gSaveContext.buttonStatus[i] = status;
                     }
                 }
-
-                if (interfaceCtx->restrictions.ocarina != 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_FAIRY) ||
-                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_OF_TIME)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                        }
-                    }
-                } else if (interfaceCtx->restrictions.ocarina == 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_FAIRY) ||
-                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_OCARINA_OF_TIME)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
-                        }
+                for (i=0; i<4; i++) {
+                    item = Interface_GetItemFromDpad(i);
+                    if (item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK) {
+                        if (dpadStatus[i] != status)
+                            sp28 = true;
+                        dpadStatus[i] = status;
                     }
                 }
-
-                if (interfaceCtx->restrictions.farores != 0) {
-                    for (i = 1; i < 4; i++) {
-                        if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_FARORES_WIND) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                            PRINTF("***(i=%d)***  ", i);
-                        }
-                    }
-                } else if (interfaceCtx->restrictions.farores == 0) {
-                    for (i = 1; i < 4; i++) {
-                        if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_FARORES_WIND) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
-                        }
+            
+                status = !interfaceCtx->restrictions.hookshot;
+                for (i=1; i<4; i++) {
+                    item = gSaveContext.save.info.equips.buttonItems[i];
+                    if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT) {
+                        if (gSaveContext.buttonStatus[i] != status)
+                            sp28 = true;
+                        gSaveContext.buttonStatus[i] = status;
                     }
                 }
-
-                if (interfaceCtx->restrictions.dinsNayrus != 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_DINS_FIRE) ||
-                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_NAYRUS_LOVE)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                        }
-                    }
-                } else if (interfaceCtx->restrictions.dinsNayrus == 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] == ITEM_DINS_FIRE) ||
-                            (gSaveContext.save.info.equips.buttonItems[i] == ITEM_NAYRUS_LOVE)) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
-                                sp28 = true;
-                            }
-
-                            gSaveContext.buttonStatus[i] = BTN_ENABLED;
-                        }
+                for (i=0; i<4; i++) {
+                    item = Interface_GetItemFromDpad(i);
+                    if (item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT) {
+                        if (dpadStatus[i] != status)
+                            sp28 = true;
+                        dpadStatus[i] = status;
                     }
                 }
-
-                if (interfaceCtx->restrictions.all != 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME) &&
-                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
-                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) &&
-                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
-                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK))) {
-                            if ((play->sceneId != SCENE_TREASURE_BOX_SHOP) ||
-                                (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LENS_OF_TRUTH)) {
-                                if (gSaveContext.buttonStatus[i] == BTN_ENABLED) {
+            
+                status = !interfaceCtx->restrictions.ocarina;
+                for (i=1; i<4; i++) {
+                    item = gSaveContext.save.info.equips.buttonItems[i];
+                    if (item == ITEM_OCARINA_FAIRY || item == ITEM_OCARINA_OF_TIME) {
+                        if (gSaveContext.buttonStatus[i] != status)
+                            sp28 = true;
+                        gSaveContext.buttonStatus[i] = status;
+                    }
+                }
+                for (i=0; i<4; i++) {
+                    item = Interface_GetItemFromDpad(i);
+                    if (item == ITEM_OCARINA_FAIRY || item == ITEM_OCARINA_OF_TIME) {
+                        if (dpadStatus[i] != status)
+                            sp28 = true;
+                        dpadStatus[i] = status;
+                    }
+                }
+            
+                status = !interfaceCtx->restrictions.farores;
+                for (i=1; i<4; i++) {
+                    item = gSaveContext.save.info.equips.buttonItems[i];
+                    if (item == ITEM_FARORES_WIND) {
+                        if (gSaveContext.buttonStatus[i] != status)
+                            sp28 = true;
+                        gSaveContext.buttonStatus[i] = status;
+                    }
+                }
+                for (i=0; i<4; i++) {
+                    item = Interface_GetItemFromDpad(i);
+                    if (item == ITEM_FARORES_WIND) {
+                        if (dpadStatus[i] != status)
+                            sp28 = true;
+                        dpadStatus[i] = status;
+                    }
+                }
+            
+                status = !interfaceCtx->restrictions.dinsNayrus;
+                for (i=1; i<4; i++) {
+                    item = gSaveContext.save.info.equips.buttonItems[i];
+                    if (item == ITEM_DINS_FIRE || item == ITEM_NAYRUS_LOVE) {
+                        if (gSaveContext.buttonStatus[i] != status)
+                            sp28 = true;
+                        gSaveContext.buttonStatus[i] = status;
+                    }
+                }
+                for (i=0; i<4; i++) {
+                    item = Interface_GetItemFromDpad(i);
+                    if (item == ITEM_DINS_FIRE || item == ITEM_NAYRUS_LOVE) {
+                        if (dpadStatus[i] != status)
+                            sp28 = true;
+                        dpadStatus[i] = status;
+                    }
+                }
+                
+                if (interfaceCtx->restrictions.all) {
+                    for (i=1; i<4; i++) {
+                        item = gSaveContext.save.info.equips.buttonItems[i];
+                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                            if (play->sceneId != SCENE_TREASURE_BOX_SHOP || gSaveContext.save.info.equips.buttonItems[i] != ITEM_LENS_OF_TRUTH) {
+                                if (gSaveContext.buttonStatus[i] == BTN_ENABLED)
                                     sp28 = true;
-                                }
-
                                 gSaveContext.buttonStatus[i] = BTN_DISABLED;
-                            } else {
-                                if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
+                            }
+                            else {
+                                if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
                                     sp28 = true;
-                                }
-
                                 gSaveContext.buttonStatus[i] = BTN_ENABLED;
                             }
                         }
                     }
-                } else if (interfaceCtx->restrictions.all == 0) {
-                    for (i = 1; i < 4; i++) {
-                        if ((gSaveContext.save.info.equips.buttonItems[i] != ITEM_DINS_FIRE) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_HOOKSHOT) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_LONGSHOT) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_FARORES_WIND) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_NAYRUS_LOVE) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_FAIRY) &&
-                            (gSaveContext.save.info.equips.buttonItems[i] != ITEM_OCARINA_OF_TIME) &&
-                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_BOTTLE_EMPTY) &&
-                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_BOTTLE_POE)) &&
-                            !((gSaveContext.save.info.equips.buttonItems[i] >= ITEM_WEIRD_EGG) &&
-                              (gSaveContext.save.info.equips.buttonItems[i] <= ITEM_CLAIM_CHECK))) {
-                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED) {
-                                sp28 = true;
+                    for (i=0; i<4; i++) {
+                        item = Interface_GetItemFromDpad(i);
+                        if (item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                            if (play->sceneId != SCENE_TREASURE_BOX_SHOP || item != ITEM_LENS_OF_TRUTH) {
+                                if (dpadStatus[i] == BTN_ENABLED)
+                                    sp28 = true;
+                                dpadStatus[i] = BTN_DISABLED;
                             }
-
+                            else {
+                                if (dpadStatus[i] == BTN_DISABLED)
+                                    sp28 = true;
+                                dpadStatus[i] = BTN_ENABLED;
+                            }
+                        }
+                    }
+                }
+                else if (!interfaceCtx->restrictions.all) {
+                    for (i=1; i<4; i++) {
+                        item = gSaveContext.save.info.equips.buttonItems[i];
+                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                            if (gSaveContext.buttonStatus[i] == BTN_DISABLED)
+                                sp28 = true;
                             gSaveContext.buttonStatus[i] = BTN_ENABLED;
+                        }
+                    }
+                    for (i=0; i<4; i++) {
+                        item = Interface_GetItemFromDpad(i);
+                        if (item != ITEM_DINS_FIRE && item != ITEM_HOOKSHOT && item != ITEM_LONGSHOT && item != ITEM_FARORES_WIND && item != ITEM_NAYRUS_LOVE && item != ITEM_OCARINA_FAIRY && item != ITEM_OCARINA_OF_TIME && !(item >= ITEM_BOTTLE_EMPTY && item <= ITEM_BOTTLE_POE) && !(item >= ITEM_WEIRD_EGG && item <= ITEM_CLAIM_CHECK)) {
+                            if (dpadStatus[i] == BTN_DISABLED)
+                                sp28 = true;
+                            dpadStatus[i] = BTN_ENABLED;
                         }
                     }
                 }
@@ -1380,11 +1396,21 @@ void func_800849EC(PlayState* play) {
 
 void Interface_LoadItemIcon1(PlayState* play, u8 button) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    Player* player = GET_PLAYER(play);
+    u8 item;
+
+    if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_SWORDS)
+        item = (player->currentSwordItemId == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : player->currentSwordItemId;
+    else if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_SHIELDS)
+        item = (player->currentShield == 0) ? ITEM_NONE : (ITEM_SHIELD_DEKU + player->currentShield - 1);
+    else if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_TUNICS)
+        item = ITEM_TUNIC_KOKIRI + player->currentTunic;
+    else if (gSaveContext.save.info.equips.buttonItems[button] == ITEM_BOOTS)
+        item = ITEM_BOOTS_KOKIRI + player->currentBoots;
+    else item = gSaveContext.save.info.equips.buttonItems[button];
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
-    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (button * ITEM_ICON_SIZE),
-                      GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[button]), ITEM_ICON_SIZE, 0,
-                      &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1171);
+    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (button * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1171);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
 
@@ -1439,9 +1465,7 @@ u8 Interface_GetArrowFromDpad(u8 button) {
 }
 
 u8 Interface_GetItemFromDpad(u8 button) {
-    if (dpadStatus[button] == BTN_DISABLED)
-        return ITEM_NONE;
-    else if (DPAD_BUTTON(button) < SLOT_SWORDS)
+    if (DPAD_BUTTON(button) < SLOT_SWORDS)
         return DPAD_BUTTON_ITEM(button);
     else if (DPAD_BUTTON(button) == SLOT_SWORDS)
         return ITEM_SWORDS;
@@ -3024,7 +3048,7 @@ void Interface_DrawItemButtons(PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 2900);
 
-    if (!gSaveContext.save.info.playerData.dpadDualSet)
+    if (gSaveContext.save.info.playerData.dpadDualSet)
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[0]);
     else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 192, 192, 192, dpadAlphas[0]);
     gDPLoadTextureBlock(OVERLAY_DISP++, gDpadTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -3209,18 +3233,18 @@ void Interface_DrawItemIconTexture(PlayState* play, void* texture, u8 button) {
         y     = dpad_icon_y[button-4];
         dd    = 1400;
         width = 12;
-    }
-    
-    if (button < 4)
-        item = gSaveContext.save.info.equips.buttonItems[button];
-    else item = Interface_GetItemFromDpad(button-4);
+        
+        if (button < 4)
+            item = gSaveContext.save.info.equips.buttonItems[button];
+        else item = Interface_GetItemFromDpad(button-4);
 
-    if ( (item == ITEM_TUNIC_GORON && player->currentTunic == 1) || (item == ITEM_TUNIC_ZORA && player->currentTunic == 2) || (item == ITEM_BOOTS_IRON && player->currentBoots == 1) || (item == ITEM_BOOTS_HOVER && player->currentBoots == 2) || (item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH && player->currentMask == item - ITEM_MASK_KEATON + 1) ) {
-        dd    *=  0.8;
-        width +=  3;
-        offset = -1;
+        if ( (item == ITEM_TUNIC_GORON && player->currentTunic == 1) || (item == ITEM_TUNIC_ZORA && player->currentTunic == 2) || (item == ITEM_BOOTS_IRON && player->currentBoots == 1) || (item == ITEM_BOOTS_HOVER && player->currentBoots == 2) || (item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH && player->currentMask == item - ITEM_MASK_KEATON + 1) ) {
+            dd    *=  0.8;
+            width +=  3;
+            offset = -1;
+        }
     }
-    
+
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 3079);
 
     gDPLoadTextureBlock(OVERLAY_DISP++, texture, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP,

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -153,6 +153,14 @@ static s16 sMagicBorderR = 255;
 static s16 sMagicBorderG = 255;
 static s16 sMagicBorderB = 255;
 
+u8 dpadStatus[] = { BTN_ENABLED, BTN_ENABLED, BTN_ENABLED, BTN_ENABLED };
+u8 dpadAlphas[] = { 0, 0, 0, 0, 0 };
+
+const u16 dpad_icon_x[] = { D_UP_BUTTON_X,     D_RIGHT_BUTTON_X,     D_DOWN_BUTTON_X,     D_LEFT_BUTTON_X };
+const u16 dpad_icon_y[] = { D_UP_BUTTON_Y,     D_RIGHT_BUTTON_Y,     D_DOWN_BUTTON_Y,     D_LEFT_BUTTON_Y };
+const u16 dpad_ammo_x[] = { D_UP_BUTTON_X + 1, D_RIGHT_BUTTON_X + 1, D_DOWN_BUTTON_X + 1, D_LEFT_BUTTON_X + 1 };
+const u16 dpad_ammo_y[] = { D_UP_BUTTON_Y + 8, D_RIGHT_BUTTON_Y + 8, D_DOWN_BUTTON_Y + 8, D_LEFT_BUTTON_Y + 8 };
+
 static s16 sExtraItemBases[] = {
     ITEM_DEKU_STICK, // ITEM_DEKU_STICKS_5
     ITEM_DEKU_STICK, // ITEM_DEKU_STICKS_10
@@ -203,6 +211,7 @@ void Interface_ChangeHudVisibilityMode(u16 hudVisibilityMode) {
  */
 void Interface_RaiseButtonAlphas(PlayState* play, s16 risingAlpha) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    u8 i;
 
     if (gSaveContext.buttonStatus[0] == BTN_DISABLED) {
         if (interfaceCtx->bAlpha != 70) {
@@ -253,6 +262,30 @@ void Interface_RaiseButtonAlphas(PlayState* play, s16 risingAlpha) {
             interfaceCtx->aAlpha = risingAlpha;
         }
     }
+    
+    if (dpadStatus[0] == BTN_DISABLED && dpadStatus[1] == BTN_DISABLED && dpadStatus[2] == BTN_DISABLED && dpadStatus[3] == BTN_DISABLED) {
+        if (dpadAlphas[0] != 70)
+            dpadAlphas[0] = 70;
+    }
+    else if (dpadAlphas[0] != 255)
+        dpadAlphas[0] = risingAlpha;
+    
+    for (i=1; i<5; i++) {
+        if (dpadStatus[i-1] == BTN_DISABLED) {
+            if (dpadAlphas[i] != 70)
+                dpadAlphas[i] = 70;
+        }
+        else if (dpadAlphas[i] != 255)
+            dpadAlphas[i] = risingAlpha;
+    }
+}
+
+void updateDpadAlphas(u8 dimmingAlpha) {
+    u8 i;
+
+    for (i=0; i<5; i++)
+        if (dpadAlphas[i] != 0 && dpadAlphas[i] > dimmingAlpha)
+            dpadAlphas[i] = dimmingAlpha;
 }
 
 /**
@@ -286,6 +319,8 @@ void Interface_DimButtonAlphas(PlayState* play, s16 dimmingAlpha, s16 risingAlph
     if ((interfaceCtx->cRightAlpha != 0) && (interfaceCtx->cRightAlpha > dimmingAlpha)) {
         interfaceCtx->cRightAlpha = dimmingAlpha;
     }
+    
+    updateDpadAlphas(dimmingAlpha);
 }
 
 void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
@@ -338,6 +373,7 @@ void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
 
             PRINTF("a_alpha=%d, c_alpha=%d\n", interfaceCtx->aAlpha, interfaceCtx->cLeftAlpha);
 
+            updateDpadAlphas(dimmingAlpha);
             break;
 
         case HUD_VISIBILITY_HEARTS_FORCE:
@@ -400,6 +436,7 @@ void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
                 interfaceCtx->aAlpha = risingAlpha;
             }
 
+            updateDpadAlphas(dimmingAlpha);
             break;
 
         case HUD_VISIBILITY_A_HEARTS_MAGIC_FORCE:
@@ -526,6 +563,7 @@ void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
                 interfaceCtx->magicAlpha = risingAlpha;
             }
 
+            updateDpadAlphas(dimmingAlpha);
             break;
 
         case HUD_VISIBILITY_B_ALT:
@@ -561,6 +599,7 @@ void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
                 interfaceCtx->bAlpha = risingAlpha;
             }
 
+            updateDpadAlphas(dimmingAlpha);
             break;
 
         case HUD_VISIBILITY_HEARTS:
@@ -596,6 +635,7 @@ void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
                 interfaceCtx->healthAlpha = risingAlpha;
             }
 
+            updateDpadAlphas(dimmingAlpha);
             break;
 
         case HUD_VISIBILITY_A_B_MINIMAP:
@@ -631,6 +671,7 @@ void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
                 interfaceCtx->healthAlpha = dimmingAlpha;
             }
 
+            updateDpadAlphas(dimmingAlpha);
             break;
 
         case HUD_VISIBILITY_HEARTS_MAGIC_FORCE:
@@ -679,7 +720,7 @@ void func_80083108(PlayState* play) {
 
                 if (gSaveContext.buttonStatus[0] == BTN_DISABLED) {
                     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                        gSaveContext.buttonStatus[3] = BTN_ENABLED;
+                        gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
                 }
 
                 if ((gSaveContext.save.info.equips.buttonItems[0] != ITEM_SLINGSHOT) &&
@@ -708,7 +749,7 @@ void func_80083108(PlayState* play) {
                         }
                     }
 
-                    gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] = gSaveContext.buttonStatus[3] =
+                    gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] = gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] =
                         BTN_DISABLED;
                     Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_FORCE);
                 }
@@ -755,7 +796,7 @@ void func_80083108(PlayState* play) {
                 }
 
                 gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                    gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                    gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                 Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
             } else {
                 if (gSaveContext.buttonStatus[0] == BTN_ENABLED) {
@@ -763,7 +804,7 @@ void func_80083108(PlayState* play) {
                 }
 
                 gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                    gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                    gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                 Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
             }
         } else if (msgCtx->msgMode == MSGMODE_NONE) {
@@ -811,6 +852,8 @@ void func_80083108(PlayState* play) {
                     gSaveContext.buttonStatus[1] = BTN_DISABLED;
                     gSaveContext.buttonStatus[2] = BTN_DISABLED;
                     gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                    dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
+                    
                     gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                     Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
                 }
@@ -1335,7 +1378,7 @@ void func_800849EC(PlayState* play) {
     Interface_LoadItemIcon1(play, 0);
 }
 
-void Interface_LoadItemIcon1(PlayState* play, u16 button) {
+void Interface_LoadItemIcon1(PlayState* play, u8 button) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
@@ -1345,7 +1388,7 @@ void Interface_LoadItemIcon1(PlayState* play, u16 button) {
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
 
-void Interface_LoadItemIcon2(PlayState* play, u16 button) {
+void Interface_LoadItemIcon2(PlayState* play, u8 button) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
@@ -1353,6 +1396,70 @@ void Interface_LoadItemIcon2(PlayState* play, u16 button) {
                       GET_ITEM_ICON_VROM(gSaveContext.save.info.equips.buttonItems[button]), ITEM_ICON_SIZE, 0,
                       &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
+}
+
+void Interface_LoadItemIconDpad(PlayState* play, u8 button) {
+    InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    Player* player = GET_PLAYER(play);
+    u8 item;
+    
+    if (DPAD_BUTTON(button) < SLOT_SWORDS)
+        item = DPAD_BUTTON_ITEM(button);
+    else if (DPAD_BUTTON(button) == SLOT_SWORDS)
+        item = (player->currentSwordItemId == ITEM_GIANTS_KNIFE) ? ITEM_GIANTS_KNIFE : player->currentSwordItemId;
+    else if (DPAD_BUTTON(button) == SLOT_SHIELDS)
+        item = (player->currentShield == 0) ? ITEM_NONE : (ITEM_SHIELD_DEKU + player->currentShield - 1);
+    else if (DPAD_BUTTON(button) == SLOT_TUNICS)
+        item = ITEM_TUNIC_KOKIRI + player->currentTunic;
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS)
+        item = ITEM_BOOTS_KOKIRI + player->currentBoots;
+    else if (DPAD_BUTTON(button) == SLOT_TUNIC_GORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON))
+        item = ITEM_TUNIC_GORON;
+    else if (DPAD_BUTTON(button) == SLOT_TUNIC_ZORA  && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA))
+        item = ITEM_TUNIC_ZORA;
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS_IRON  && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON))
+        item = ITEM_BOOTS_IRON;
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS_HOVER && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER))
+        item = ITEM_BOOTS_HOVER;
+    else item = ITEM_NONE;
+
+    osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
+    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + ((button+4) * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
+    osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
+}
+
+u8 Interface_GetArrowFromDpad(u8 button) {
+    if (gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_FIRE)
+        return ITEM_BOW_FIRE;
+    else if (gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_ICE)
+        return ITEM_BOW_ICE;
+    else if (gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)] == ITEM_ARROW_LIGHT)
+        return ITEM_BOW_LIGHT;
+    else return gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)];
+}
+
+u8 Interface_GetItemFromDpad(u8 button) {
+    if (dpadStatus[button] == BTN_DISABLED)
+        return ITEM_NONE;
+    else if (DPAD_BUTTON(button) < SLOT_SWORDS)
+        return DPAD_BUTTON_ITEM(button);
+    else if (DPAD_BUTTON(button) == SLOT_SWORDS)
+        return ITEM_SWORDS;
+    else if (DPAD_BUTTON(button) == SLOT_SHIELDS)
+        return ITEM_SHIELDS;
+    else if (DPAD_BUTTON(button) == SLOT_TUNICS)
+        return ITEM_TUNICS;
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS)
+        return ITEM_BOOTS;
+    else if (DPAD_BUTTON(button) == SLOT_TUNIC_GORON)
+        return ITEM_TUNIC_GORON;
+    else if (DPAD_BUTTON(button) == SLOT_TUNIC_ZORA)
+        return ITEM_TUNIC_ZORA;
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS_IRON)
+        return ITEM_BOOTS_IRON;
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS_HOVER)
+        return ITEM_BOOTS_HOVER;
+    else return ITEM_NONE;
 }
 
 void func_80084BF4(PlayState* play, u16 flag) {
@@ -1378,23 +1485,23 @@ void func_80084BF4(PlayState* play, u16 flag) {
         }
 
         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-            gSaveContext.buttonStatus[3] = BTN_ENABLED;
+            gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL_NO_MINIMAP_BY_BTN_STATUS);
     } else {
         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-            gSaveContext.buttonStatus[3] = BTN_ENABLED;
+            gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
         func_80083108(play);
     }
 }
 
 u8 Item_Give(PlayState* play, u8 item) {
-    static s16 sAmmoRefillCounts[] = { 5, 10, 20, 30 }; // Sticks, nuts, bombs
-    static s16 sArrowRefillCounts[] = { 5, 10, 30 };
-    static s16 sBombchuRefillCounts[] = { 5, 20 };
-    static s16 sRupeeRefillCounts[] = { 1, 5, 20, 50, 200, 10 };
-    s16 i;
-    s16 slot;
-    s16 temp;
+    static u8 sAmmoRefillCounts[] = { 5, 10, 20, 30 }; // Sticks, nuts, bombs
+    static u8 sArrowRefillCounts[] = { 5, 10, 30 };
+    static u8 sBombchuRefillCounts[] = { 5, 20 };
+    static u8 sRupeeRefillCounts[] = { 1, 5, 20, 50, 200, 10 };
+    u8 i, j;
+    u8 slot;
+    u8 temp;
 
     slot = SLOT(item);
     if (item >= ITEM_DEKU_STICKS_5) {
@@ -1604,6 +1711,9 @@ u8 Item_Give(PlayState* play, u8 item) {
                 Interface_LoadItemIcon1(play, i);
             }
         }
+        for (i=0; i<4; i++)
+            if (DPAD_BUTTON(i) == SLOT_HOOKSHOT)
+                Interface_LoadItemIconDpad(play, i);
         return ITEM_NONE;
     } else if (item == ITEM_DEKU_STICK) {
         if (gSaveContext.save.info.inventory.items[slot] == ITEM_NONE) {
@@ -1734,6 +1844,9 @@ u8 Item_Give(PlayState* play, u8 item) {
                 Interface_LoadItemIcon1(play, i);
             }
         }
+        for (i=0; i<4; i++)
+            if (DPAD_BUTTON(i) == SLOT_OCARINA)
+                Interface_LoadItemIconDpad(play, i);
         return ITEM_NONE;
     } else if (item == ITEM_MAGIC_BEAN) {
         if (gSaveContext.save.info.inventory.items[slot] == ITEM_NONE) {
@@ -1838,6 +1951,12 @@ u8 Item_Give(PlayState* play, u8 item) {
                         gSaveContext.buttonStatus[3] = BTN_ENABLED;
                     }
 
+                    for (j=0; j<4; j++)
+                        if (DPAD_BUTTON_ITEM(j) == temp + i) {
+                            Interface_LoadItemIconDpad(play, j);
+                            dpadStatus[j] = BTN_ENABLED;
+                        }
+                    
                     gSaveContext.save.info.inventory.items[temp + i] = item;
                     return ITEM_NONE;
                 }
@@ -1880,9 +1999,9 @@ u8 Item_Give(PlayState* play, u8 item) {
 }
 
 u8 Item_CheckObtainability(u8 item) {
-    s16 i;
-    s16 slot = SLOT(item);
-    s16 temp;
+    u8 i;
+    u8 slot = SLOT(item);
+    u8 temp;
 
     if (item >= ITEM_DEKU_STICKS_5) {
         slot = SLOT(sExtraItemBases[item - ITEM_DEKU_STICKS_5]);
@@ -2026,7 +2145,7 @@ void Inventory_DeleteItem(u16 item, u16 invSlot) {
 }
 
 s32 Inventory_ReplaceItem(PlayState* play, u16 oldItem, u16 newItem) {
-    s16 i;
+    u8 i;
 
     for (i = 0; i < ARRAY_COUNT(gSaveContext.save.info.inventory.items); i++) {
         if (gSaveContext.save.info.inventory.items[i] == oldItem) {
@@ -2036,9 +2155,11 @@ s32 Inventory_ReplaceItem(PlayState* play, u16 oldItem, u16 newItem) {
                 if (gSaveContext.save.info.equips.buttonItems[i] == oldItem) {
                     gSaveContext.save.info.equips.buttonItems[i] = newItem;
                     Interface_LoadItemIcon1(play, i);
-                    return true;
                 }
             }
+            for (i=0; i<4; i++)
+                if (DPAD_BUTTON_ITEM(i) == oldItem)
+                    Interface_LoadItemIconDpad(play, i);                 
             return true;
         }
     }
@@ -2071,9 +2192,28 @@ s32 Inventory_HasSpecificBottle(u8 bottleItem) {
 }
 
 void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
+    u8 i;
+    
     PRINTF("item_no=%x,  c_no=%x,  Pt=%x  Item_Register=%x\n", item, button,
            gSaveContext.save.info.equips.cButtonSlots[button - 1],
            gSaveContext.save.info.inventory.items[gSaveContext.save.info.equips.cButtonSlots[button - 1]]);
+
+    if (button >= 4) {
+        if (gSaveContext.save.info.inventory.items[DPAD_BUTTON(button-4)] == ITEM_BOTTLE_MILK_FULL && item == ITEM_BOTTLE_EMPTY)
+            item = ITEM_BOTTLE_MILK_HALF;
+        
+        for (i=1; i<4; i++)
+            if (gSaveContext.save.info.equips.cButtonSlots[i-1] == DPAD_BUTTON(button-4)) {
+                gSaveContext.save.info.equips.cButtonSlots[i-1] = gSaveContext.save.info.equips.buttonItems[i] = item;
+                Interface_LoadItemIcon1(play, i);
+            }
+        
+        gSaveContext.save.info.inventory.items[DPAD_BUTTON(button-4)] = item;
+        Interface_LoadItemIconDpad(play, button-4);
+        dpadStatus[button-4] = BTN_ENABLED;
+        
+        return;
+    }
 
     // Special case to only empty half of a Lon Lon Milk Bottle
     if ((gSaveContext.save.info.inventory.items[gSaveContext.save.info.equips.cButtonSlots[button - 1]] ==
@@ -2084,6 +2224,10 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
 
     gSaveContext.save.info.inventory.items[gSaveContext.save.info.equips.cButtonSlots[button - 1]] = item;
     gSaveContext.save.info.equips.buttonItems[button] = item;
+    
+    for (i=0; i<4; i++)
+        if (DPAD_BUTTON_ITEM(i) == item)
+            Interface_LoadItemIconDpad(play, i);
 
     Interface_LoadItemIcon1(play, button);
 
@@ -2092,9 +2236,9 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
 }
 
 s32 Inventory_ConsumeFairy(PlayState* play) {
-    s32 bottleSlot = SLOT(ITEM_BOTTLE_FAIRY);
-    s16 i;
-    s16 j;
+    u8 bottleSlot = SLOT(ITEM_BOTTLE_FAIRY);
+    u8 i;
+    u8 j;
 
     for (i = 0; i < 4; i++) {
         if (gSaveContext.save.info.inventory.items[bottleSlot + i] == ITEM_BOTTLE_FAIRY) {
@@ -2107,6 +2251,13 @@ s32 Inventory_ConsumeFairy(PlayState* play) {
                     break;
                 }
             }
+            
+            for (j=0; j<4; j++)
+                if (DPAD_BUTTON(j) == bottleSlot) {
+                    Interface_LoadItemIconDpad(play, j);
+                    break;
+                }
+            
             PRINTF(T("妖精使用＝%d\n", "Fairy Usage=%d\n"), bottleSlot);
             gSaveContext.save.info.inventory.items[bottleSlot + i] = ITEM_BOTTLE_EMPTY;
             return true;
@@ -2601,7 +2752,11 @@ void Magic_Update(PlayState* play) {
                      (Player_GetEnvironmentalHazard(play) <= PLAYER_ENV_HAZARD_UNDERWATER_FREE)) ||
                     ((gSaveContext.save.info.equips.buttonItems[1] != ITEM_LENS_OF_TRUTH) &&
                      (gSaveContext.save.info.equips.buttonItems[2] != ITEM_LENS_OF_TRUTH) &&
-                     (gSaveContext.save.info.equips.buttonItems[3] != ITEM_LENS_OF_TRUTH)) ||
+                     (gSaveContext.save.info.equips.buttonItems[3] != ITEM_LENS_OF_TRUTH) &&
+                     (DPAD_BUTTON_ITEM(0)                          != ITEM_LENS_OF_TRUTH) &&
+                     (DPAD_BUTTON_ITEM(1)                          != ITEM_LENS_OF_TRUTH) &&
+                     (DPAD_BUTTON_ITEM(2)                          != ITEM_LENS_OF_TRUTH) &&
+                     (DPAD_BUTTON_ITEM(3)                          != ITEM_LENS_OF_TRUTH)) ||
                     !play->actorCtx.lensActive) {
                     // Force lens off and set magic meter state to idle
                     play->actorCtx.lensActive = false;
@@ -2804,6 +2959,52 @@ void Interface_DrawActionLabel(GraphicsContext* gfxCtx, void* texture) {
     CLOSE_DISPS(gfxCtx, "../z_parameter.c", 2829);
 }
 
+const u32 gDpadTex[] = {
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0xf7f7f7ff, 0xd7d7d7ff, 0xc2c2c2ff,
+    0xbababaff, 0xa1a1a1ff, 0x434343ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0xffffffff, 0xfdfdfdff, 0xe2e2e2ff, 0xcacacaff, 0xc3c3c3ff, 0x9e9e9eff, 0x393939ff, 0x181818ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xfbfbfbff, 0xfefefeff, 0xf4f4f4ff, 0xcacacaff, 0x8a8a8aff, 0x797979ff, 0x626262ff, 0x404040ff, 0x111111ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xf1f1f1ff, 0xf1f1f1ff, 0xd9d9d9ff, 0xa7a7a7ff, 0x000000ff,
+    0x0e0e0eff, 0x757575ff, 0x5f5f5fff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x000000ff, 0xf1f1f1ff, 0xecececff, 0xc3c3c3ff, 0x000000ff, 0x1b1b1bff, 0x696969ff, 0x7a7a7aff, 0x717171ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xf5f5f5ff, 0xf1f1f1ff, 0xcececeff, 0x7a7a7aff, 0xbfbfbfff, 0xc8c8c8ff, 0xe4e4e4ff, 0x7d7d7dff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xf9f9f9ff, 0xf4f4f4ff, 0xd8d8d8ff, 0xcacacaff, 0xbbbbbbff,
+    0xabababff, 0x9b9b9bff, 0x8a8a8aff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x000000ff, 0xfcfcfcff, 0xf8f8f8ff, 0xe2e2e2ff, 0xd5d5d5ff, 0xc7c7c7ff, 0xb7b7b7ff, 0xa7a7a7ff, 0x979797ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xfefefeff, 0xfbfbfbff, 0xebebebff, 0xdfdfdfff, 0xd1d1d1ff, 0xc3c3c3ff, 0xb3b3b3ff, 0xa3a3a3ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0xfefefeff, 0xfefefeff, 0xf2f2f2ff, 0xe8e8e8ff, 0xdcdcdcff,
+    0xcececeff, 0xbfbfbfff, 0xafafafff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0xf5f5f5ff, 0xdcdcdcff, 0xd7d7d7ff, 0xdededeff, 0xe5e5e5ff,
+    0xebebebff, 0xf1f1f1ff, 0xfbfbfbff, 0xffffffff, 0xffffffff, 0xf9f9f9ff, 0xf0f0f0ff, 0xe5e5e5ff, 0xd8d8d8ff, 0xcacacaff, 0xbbbbbbff, 0x555555ff, 0x4d4d4dff, 0xa9a9a9ff, 0xc5c5c5ff, 0xbebebeff, 0xb7b7b7ff, 0xb0b0b0ff, 0xa9a9a9ff, 0x8d8d8dff, 0x212121ff, 0x000000ff, 0x00000096, 0x00000000,
+    0x00000096, 0x000000ff, 0xfefefeff, 0xfcfcfcff, 0xe0e0e0ff, 0xd5d5d5ff, 0xdbdbdbff, 0xe2e2e2ff, 0xe8e8e8ff, 0xeeeeeeff, 0xf6f6f6ff, 0xfbfbfbff, 0xfbfbfbff, 0xffffffff, 0xf7f7f7ff, 0xedededff, 0xe2e2e2ff, 0xd5d5d5ff, 0xc7c7c7ff, 0xadadadff, 0xacacacff, 0xc5c5c5ff, 0xcececeff, 0xc7c7c7ff,
+    0xc0c0c0ff, 0xb9b9b9ff, 0xb3b3b3ff, 0x878787ff, 0x1d1d1dff, 0x0b0b0bff, 0x000000ff, 0x00000096, 0x000000ff, 0xf1f1f1ff, 0xfcfcfcff, 0xecececff, 0xb8b8b8ff, 0x8a8a8aff, 0x9b9b9bff, 0xabababff, 0xbbbbbbff, 0xcacacaff, 0xd8d8d8ff, 0xe5e5e5ff, 0xf0f0f0ff, 0xf9f9f9ff, 0xfdfdfdff, 0xf5f5f5ff,
+    0xebebebff, 0xdfdfdfff, 0xd1d1d1ff, 0xc3c3c3ff, 0xb3b3b3ff, 0xa3a3a3ff, 0x939393ff, 0x828282ff, 0x717171ff, 0x606060ff, 0x505050ff, 0x3c3c3cff, 0x242424ff, 0x080808ff, 0x000000ff, 0x000000ff, 0x000000ff, 0xc0c0c0ff, 0xd1d1d1ff, 0xa9a9a9ff, 0x6c6c6cff, 0x000000ff, 0x4e4e4eff, 0x9f9f9fff,
+    0xafafafff, 0xbfbfbfff, 0xcececeff, 0xdcdcdcff, 0xe8e8e8ff, 0xf2f2f2ff, 0xfbfbfbff, 0xfbfbfbff, 0xf2f2f2ff, 0xe8e8e8ff, 0xdcdcdcff, 0xcececeff, 0xbfbfbfff, 0xafafafff, 0x9f9f9fff, 0x8e8e8eff, 0x7d7d7dff, 0x000000ff, 0x070707ff, 0x4c4c4cff, 0x393939ff, 0x000000ff, 0x000000ff, 0x000000ff,
+    0x000000ff, 0xa6a6a6ff, 0xb1b1b1ff, 0x505050ff, 0x000000ff, 0x0f0f0fff, 0xa2a2a2ff, 0x939393ff, 0xa3a3a3ff, 0xb3b3b3ff, 0xc3c3c3ff, 0xd1d1d1ff, 0xdfdfdfff, 0xebebebff, 0xf5f5f5ff, 0xfdfdfdff, 0xf9f9f9ff, 0xf0f0f0ff, 0xe5e5e5ff, 0xd8d8d8ff, 0xcacacaff, 0xbbbbbbff, 0xabababff, 0x9b9b9bff,
+    0x8a8a8aff, 0x000000ff, 0x2b2b2bff, 0x4e4e4eff, 0x484848ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0xa2a2a2ff, 0xadadadff, 0x444444ff, 0x050505ff, 0x3b3b3bff, 0xb5b5b5ff, 0x868686ff, 0x979797ff, 0xa7a7a7ff, 0xb7b7b7ff, 0xc7c7c7ff, 0xd5d5d5ff, 0xe2e2e2ff, 0xedededff, 0xf7f7f7ff,
+    0xffffffff, 0xf7f7f7ff, 0xedededff, 0xe2e2e2ff, 0xd5d5d5ff, 0xc7c7c7ff, 0xb7b7b7ff, 0xa7a7a7ff, 0x979797ff, 0x000000ff, 0x9e9e9eff, 0xd7d7d7ff, 0x545454ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x868686ff, 0x818181ff, 0x353535ff, 0x484848ff, 0x5a5a5aff, 0xdededeff, 0x797979ff,
+    0x8a8a8aff, 0x9b9b9bff, 0xabababff, 0xbbbbbbff, 0xcacacaff, 0xd8d8d8ff, 0xe5e5e5ff, 0xf0f0f0ff, 0xf9f9f9ff, 0xfdfdfdff, 0xf5f5f5ff, 0xebebebff, 0xdfdfdfff, 0xd1d1d1ff, 0xc3c3c3ff, 0xb3b3b3ff, 0xa3a3a3ff, 0x515151ff, 0xd4d4d4ff, 0x717171ff, 0x181818ff, 0x000000ff, 0x000000ff, 0x000000ff,
+    0x000000ff, 0x181818ff, 0x181818ff, 0x222222ff, 0x393939ff, 0x4c4c4cff, 0x5c5c5cff, 0x6c6c6cff, 0x7d7d7dff, 0x8e8e8eff, 0x9f9f9fff, 0xafafafff, 0xbfbfbfff, 0xcececeff, 0xdcdcdcff, 0xe8e8e8ff, 0xf2f2f2ff, 0xfbfbfbff, 0xfbfbfbff, 0xf2f2f2ff, 0xe8e8e8ff, 0xdcdcdcff, 0xcececeff, 0xbfbfbfff,
+    0xafafafff, 0x9f9f9fff, 0x8e8e8eff, 0x1f1f1fff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x000000ff, 0x090909ff, 0x080808ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x515151ff, 0xa9a9a9ff, 0xc3c3c3ff, 0xd1d1d1ff, 0xdfdfdfff,
+    0xebebebff, 0xf5f5f5ff, 0xfdfdfdff, 0x3e3e3eff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000096, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff,
+    0x000000ff, 0x000000ff, 0x000000ff, 0x4b4b4bff, 0xacacacff, 0xb7b7b7ff, 0xc7c7c7ff, 0xd5d5d5ff, 0xe2e2e2ff, 0xedededff, 0xf7f7f7ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000,
+    0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0xa9a9a9ff, 0xc7c7c7ff, 0xabababff, 0xbbbbbbff, 0xcacacaff, 0xd8d8d8ff, 0xe5e5e5ff, 0xf0f0f0ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff,
+    0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xc7c7c7ff, 0xd1d1d1ff, 0x9f9f9fff, 0xafafafff, 0xbfbfbfff,
+    0xcececeff, 0xdcdcdcff, 0xe8e8e8ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x000000ff, 0xc2c2c2ff, 0xccccccff, 0x939393ff, 0xa3a3a3ff, 0xb3b3b3ff, 0xc3c3c3ff, 0xd1d1d1ff, 0xdfdfdfff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xbcbcbcff, 0xc7c7c7ff, 0x868686ff, 0x979797ff, 0xa7a7a7ff, 0xb7b7b7ff, 0xc7c7c7ff, 0xd5d5d5ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0xb7b7b7ff, 0xc1c1c1ff, 0x797979ff, 0x000000ff, 0x000000ff,
+    0x000000ff, 0x767676ff, 0xcacacaff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x000000ff, 0xb2b2b2ff, 0xbdbdbdff, 0x6c6c6cff, 0x0d0d0dff, 0x4c4c4cff, 0xb7b7b7ff, 0xe1e1e1ff, 0xbfbfbfff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0x989898ff, 0x979797ff, 0x5b5b5bff, 0x717171ff, 0x707070ff, 0xe0e0e0ff, 0xa3a3a3ff, 0x2d2d2dff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000ff, 0x383838ff, 0x333333ff, 0x3d3d3dff, 0x5f5f5fff, 0x757575ff,
+    0x868686ff, 0x262626ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0x171717ff, 0x111111ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000096, 0x000000ff, 0x000000ff, 0x000000ff,
+    0x000000ff, 0x000000ff, 0x000000ff, 0x00000096, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 
+};
+
 void Interface_DrawItemButtons(PlayState* play) {
     static void* cUpLabelTextures[] = LANGUAGE_ARRAY(gNaviCUpJPNTex, gNaviCUpENGTex, gNaviCUpENGTex, gNaviCUpENGTex);
 #if OOT_VERSION >= PAL_1_0
@@ -2818,9 +3019,17 @@ void Interface_DrawItemButtons(PlayState* play) {
     s16 width;
     s16 height;
 #endif
+    u16 b_button_dd = 575;
+    u16 c_button_dd = 620;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 2900);
 
+    if (!gSaveContext.save.info.playerData.dpadDualSet)
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[0]);
+    else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 192, 192, 192, dpadAlphas[0]);
+    gDPLoadTextureBlock(OVERLAY_DISP++, gDpadTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+    gSPTextureRectangle(OVERLAY_DISP++, (DPAD_X) << 2, (DPAD_Y) << 2, (DPAD_X + 16) << 2, (DPAD_Y + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
+    
     // B Button Color & Texture
     // Also loads the Item Button Texture reused by other buttons afterwards
     gDPPipeSync(OVERLAY_DISP++);
@@ -2829,7 +3038,7 @@ void Interface_DrawItemButtons(PlayState* play) {
     gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
     OVERLAY_DISP =
         Gfx_TextureIA8(OVERLAY_DISP, gButtonBackgroundTex, 32, 32, R_ITEM_BTN_X(0), R_ITEM_BTN_Y(0),
-                       R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_DD(0) << 1, R_ITEM_BTN_DD(0) << 1);
+                       R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_WIDTH(0), b_button_dd << 1, b_button_dd << 1);
 
     // C-Left Button Color & Texture
     gDPPipeSync(OVERLAY_DISP++);
@@ -2837,21 +3046,21 @@ void Interface_DrawItemButtons(PlayState* play) {
                     interfaceCtx->cLeftAlpha);
     gSPTextureRectangle(OVERLAY_DISP++, R_ITEM_BTN_X(1) << 2, R_ITEM_BTN_Y(1) << 2,
                         (R_ITEM_BTN_X(1) + R_ITEM_BTN_WIDTH(1)) << 2, (R_ITEM_BTN_Y(1) + R_ITEM_BTN_WIDTH(1)) << 2,
-                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(1) << 1, R_ITEM_BTN_DD(1) << 1);
+                        G_TX_RENDERTILE, 0, 0, c_button_dd << 1, c_button_dd << 1);
 
     // C-Down Button Color & Texture
     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
                     interfaceCtx->cDownAlpha);
     gSPTextureRectangle(OVERLAY_DISP++, R_ITEM_BTN_X(2) << 2, R_ITEM_BTN_Y(2) << 2,
-                        (R_ITEM_BTN_X(2) + R_ITEM_BTN_WIDTH(2)) << 2, (R_ITEM_BTN_Y(2) + R_ITEM_BTN_WIDTH(2)) << 2,
-                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(2) << 1, R_ITEM_BTN_DD(2) << 1);
+                        (R_ITEM_BTN_X(2) + R_ITEM_BTN_WIDTH(1)) << 2, (R_ITEM_BTN_Y(2) + R_ITEM_BTN_WIDTH(1)) << 2,
+                        G_TX_RENDERTILE, 0, 0, c_button_dd << 1, c_button_dd << 1);
 
     // C-Right Button Color & Texture
     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
                     interfaceCtx->cRightAlpha);
     gSPTextureRectangle(OVERLAY_DISP++, R_ITEM_BTN_X(3) << 2, R_ITEM_BTN_Y(3) << 2,
-                        (R_ITEM_BTN_X(3) + R_ITEM_BTN_WIDTH(3)) << 2, (R_ITEM_BTN_Y(3) + R_ITEM_BTN_WIDTH(3)) << 2,
-                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(3) << 1, R_ITEM_BTN_DD(3) << 1);
+                        (R_ITEM_BTN_X(3) + R_ITEM_BTN_WIDTH(1)) << 2, (R_ITEM_BTN_Y(3) + R_ITEM_BTN_WIDTH(1)) << 2,
+                        G_TX_RENDERTILE, 0, 0, c_button_dd << 1, c_button_dd << 1);
 
     if (!IS_PAUSE_STATE_GAMEOVER(pauseCtx)) {
         if (IS_PAUSED(&play->pauseCtx)) {
@@ -2973,23 +3182,51 @@ void Interface_DrawItemButtons(PlayState* play) {
 
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex + ((32 * 32) * (temp + 1))), 32, 32,
                                           R_ITEM_BTN_X(temp), R_ITEM_BTN_Y(temp), R_ITEM_BTN_WIDTH(temp),
-                                          R_ITEM_BTN_WIDTH(temp), R_ITEM_BTN_DD(temp) << 1, R_ITEM_BTN_DD(temp) << 1);
+                                          R_ITEM_BTN_WIDTH(temp), c_button_dd << 1, c_button_dd << 1);
         }
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_parameter.c", 3071);
 }
 
-void Interface_DrawItemIconTexture(PlayState* play, void* texture, s16 button) {
+void Interface_DrawItemIconTexture(PlayState* play, void* texture, u8 button) {
+    u16 x;
+    u16 y;
+    u16 dd;
+    u8  width;
+    u8  item;
+    s8  offset = 0;
+    Player* player = GET_PLAYER(play);
+    
+    if (button < 4) {
+        x     = R_ITEM_ICON_X(button);
+        y     = R_ITEM_ICON_Y(button);
+        dd    = R_ITEM_ICON_DD(button);
+        width = R_ITEM_ICON_WIDTH(button);
+    }
+    else {
+        x     = dpad_icon_x[button-4];
+        y     = dpad_icon_y[button-4];
+        dd    = 1400;
+        width = 12;
+    }
+    
+    if (button < 4)
+        item = gSaveContext.save.info.equips.buttonItems[button];
+    else item = Interface_GetItemFromDpad(button-4);
+
+    if ( (item == ITEM_TUNIC_GORON && player->currentTunic == 1) || (item == ITEM_TUNIC_ZORA && player->currentTunic == 2) || (item == ITEM_BOOTS_IRON && player->currentBoots == 1) || (item == ITEM_BOOTS_HOVER && player->currentBoots == 2) || (item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH && player->currentMask == item - ITEM_MASK_KEATON + 1) ) {
+        dd    *=  0.8;
+        width +=  3;
+        offset = -1;
+    }
+    
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 3079);
 
     gDPLoadTextureBlock(OVERLAY_DISP++, texture, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-    gSPTextureRectangle(OVERLAY_DISP++, R_ITEM_ICON_X(button) << 2, R_ITEM_ICON_Y(button) << 2,
-                        (R_ITEM_ICON_X(button) + R_ITEM_ICON_WIDTH(button)) << 2,
-                        (R_ITEM_ICON_Y(button) + R_ITEM_ICON_WIDTH(button)) << 2, G_TX_RENDERTILE, 0, 0,
-                        R_ITEM_ICON_DD(button) << 1, R_ITEM_ICON_DD(button) << 1);
+    gSPTextureRectangle(OVERLAY_DISP++, (x + offset) << 2, (y + offset) << 2, (x + width + offset) << 2, (y + width + offset) << 2, G_TX_RENDERTILE, 0, 0, dd << 1, dd << 1);
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_parameter.c", 3094);
 }
@@ -2999,8 +3236,10 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
     s16 ammo;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_parameter.c", 3105);
-
-    i = gSaveContext.save.info.equips.buttonItems[button];
+    
+    if (button < 4)
+        i = gSaveContext.save.info.equips.buttonItems[button];
+    else i = DPAD_BUTTON_ITEM(button-4);
 
     if ((i == ITEM_DEKU_STICK) || (i == ITEM_DEKU_NUT) || (i == ITEM_BOMB) || (i == ITEM_BOW) ||
         ((i >= ITEM_BOW_FIRE) && (i <= ITEM_BOW_LIGHT)) || (i == ITEM_SLINGSHOT) || (i == ITEM_BOMBCHU) ||
@@ -3041,14 +3280,17 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
             i++;
             ammo -= 10;
         }
-
-        if (i != 0) {
-            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8,
-                                          R_ITEM_AMMO_X(button), R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
+        
+        if (button < 4) {
+            if (i != 0)
+                OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8, R_ITEM_AMMO_X(button),     R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
+            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * ammo)), 8, 8, R_ITEM_AMMO_X(button) + 6, R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
         }
-
-        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * ammo)), 8, 8,
-                                      R_ITEM_AMMO_X(button) + 6, R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
+        else {
+            if (i != 0)
+                OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * i)), 8, 8, dpad_ammo_x[button-4], dpad_ammo_y[button-4], 6, 6, 1 << 11, 1 << 11);
+            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gAmmoDigit0Tex + ((8 * 8) * ammo)), 8, 8, dpad_ammo_x[button-4] + 3, dpad_ammo_y[button-4], 6, 6, 1 << 11, 1 << 11);
+        }
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_parameter.c", 3158);
@@ -3425,6 +3667,20 @@ void Interface_Draw(PlayState* play) {
                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
             Interface_DrawAmmoCount(play, 3, interfaceCtx->cRightAlpha);
         }
+        
+        for (svar1=0; svar1<4; svar1++) {
+            gDPPipeSync(OVERLAY_DISP++);
+           
+            // D-Pad Button Icon & Ammo Count
+            if (DPAD_BUTTON_ITEM(svar1) < 0xF0 || Interface_GetItemFromDpad(svar1) < 0xF0)  {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[svar1+1]);
+                gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
+                Interface_DrawItemIconTexture(play, interfaceCtx->iconItemSegment + 0x4000 + (0x1000*svar1), 4+svar1);
+                gDPPipeSync(OVERLAY_DISP++);
+                gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+                Interface_DrawAmmoCount(play, 4+svar1,  dpadAlphas[svar1+1]);
+            }
+        }
 
         // A Button
         Gfx_SetupDL_42Overlay(play->state.gfxCtx);
@@ -3606,6 +3862,9 @@ void Interface_Draw(PlayState* play) {
                             Interface_LoadItemIcon1(play, svar2);
                         }
                     }
+                    for (svar2=0; svar2<4; svar2++)
+                        if (DPAD_BUTTON_ITEM(svar2) == gSpoilingItemReverts[svar1])
+                            Interface_LoadItemIconDpad(play, svar2);
                 }
             }
         }

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -28,7 +28,6 @@
 #include "assets/textures/parameter_static/parameter_static.h"
 #include "assets/textures/do_action_static/do_action_static.h"
 #include "assets/textures/icon_item_static/icon_item_static.h"
-#include "assets/textures/nes_font_static/nes_font_static.h"
 
 typedef struct RestrictionFlags {
     /* 0x00 */ u8 sceneId;
@@ -707,8 +706,6 @@ void func_80083108(PlayState* play) {
     MessageContext* msgCtx = &play->msgCtx;
     s16 i;
     s16 sp28 = false;
-    u8 status;
-    u8 item;
 
     if ((gSaveContext.save.cutsceneIndex < 0xFFF0) ||
         ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == 0xFFF0))) {
@@ -721,7 +718,8 @@ void func_80083108(PlayState* play) {
 
                 if (gSaveContext.buttonStatus[0] == BTN_DISABLED) {
                     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                        gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+                        gSaveContext.buttonStatus[3] = BTN_ENABLED;
+                    dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
                 }
 
                 if ((gSaveContext.save.info.equips.buttonItems[0] != ITEM_SLINGSHOT) &&
@@ -750,8 +748,9 @@ void func_80083108(PlayState* play) {
                         }
                     }
 
-                    gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] = gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] =
+                    gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] = gSaveContext.buttonStatus[3] =
                         BTN_DISABLED;
+                    dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                     Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_FORCE);
                 }
 
@@ -797,7 +796,8 @@ void func_80083108(PlayState* play) {
                 }
 
                 gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                    gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
+                    gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                 Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
             } else {
                 if (gSaveContext.buttonStatus[0] == BTN_ENABLED) {
@@ -805,7 +805,8 @@ void func_80083108(PlayState* play) {
                 }
 
                 gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-                    gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
+                    gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                 Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
             }
         } else if (msgCtx->msgMode == MSGMODE_NONE) {
@@ -965,6 +966,8 @@ void func_80083108(PlayState* play) {
 
                 Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
             } else {
+                u8 status, item;
+
                 if (interfaceCtx->restrictions.bButton == 0) {
                     if ((gSaveContext.save.info.equips.buttonItems[0] == ITEM_SLINGSHOT) ||
                         (gSaveContext.save.info.equips.buttonItems[0] == ITEM_BOW) ||
@@ -1244,7 +1247,7 @@ void Interface_SetSceneRestrictions(PlayState* play) {
         i++;
     } while (sRestrictionFlags[i].sceneId != 0xFF);
     
-    if (interfaceCtx->restrictions.tradeItems == 0)
+    if (!interfaceCtx->restrictions.tradeItems)
         GET_PLAYER(play)->currentMask = GET_MASK_AGE();
 }
 
@@ -1487,13 +1490,13 @@ u8 Interface_GetItemFromDpad(u8 button) {
         return ITEM_TUNICS;
     else if (DPAD_BUTTON(button) == SLOT_BOOTS)
         return ITEM_BOOTS;
-    else if (DPAD_BUTTON(button) == SLOT_TUNIC_GORON)
+    else if (DPAD_BUTTON(button) == SLOT_TUNIC_GORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON))
         return ITEM_TUNIC_GORON;
-    else if (DPAD_BUTTON(button) == SLOT_TUNIC_ZORA)
+    else if (DPAD_BUTTON(button) == SLOT_TUNIC_ZORA  && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA))
         return ITEM_TUNIC_ZORA;
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS_IRON)
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS_IRON  && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON))
         return ITEM_BOOTS_IRON;
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS_HOVER)
+    else if (DPAD_BUTTON(button) == SLOT_BOOTS_HOVER && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER))
         return ITEM_BOOTS_HOVER;
     else return ITEM_NONE;
 }
@@ -1521,11 +1524,13 @@ void func_80084BF4(PlayState* play, u16 flag) {
         }
 
         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-            gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+            gSaveContext.buttonStatus[3] = BTN_ENABLED;
+        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL_NO_MINIMAP_BY_BTN_STATUS);
     } else {
         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-            gSaveContext.buttonStatus[3] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+            gSaveContext.buttonStatus[3] = BTN_ENABLED;
+        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
         func_80083108(play);
     }
 }
@@ -1536,7 +1541,6 @@ u8 Item_Give(PlayState* play, u8 item) {
     static s16 sBombchuRefillCounts[] = { 5, 20 };
     static s16 sRupeeRefillCounts[] = { 1, 5, 20, 50, 200, 10 };
     s16 i;
-    s16 j;
     s16 slot;
     s16 temp;
 
@@ -1962,6 +1966,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         temp = SLOT(item);
 
         if ((item != ITEM_BOTTLE_MILK_FULL) && (item != ITEM_BOTTLE_RUTOS_LETTER)) {
+            s16 j;
             if (item == ITEM_MILK) {
                 item = ITEM_BOTTLE_MILK_FULL;
                 temp = SLOT(item);
@@ -2288,13 +2293,13 @@ s32 Inventory_ConsumeFairy(PlayState* play) {
                     break;
                 }
             }
-            
+
             for (j=0; j<4; j++)
                 if (DPAD_BUTTON(j) == bottleSlot) {
                     Interface_LoadItemIconDpad(play, j);
                     break;
                 }
-            
+
             PRINTF(T("妖精使用＝%d\n", "Fairy Usage=%d\n"), bottleSlot);
             gSaveContext.save.info.inventory.items[bottleSlot + i] = ITEM_BOTTLE_EMPTY;
             return true;
@@ -3063,11 +3068,13 @@ void Interface_DrawItemButtons(PlayState* play) {
     if ( (gSaveContext.timerState == TIMER_STATE_ENV_HAZARD_TICK || gSaveContext.timerState == TIMER_STATE_DOWN_TICK || gSaveContext.timerState == TIMER_STATE_UP_TICK || gSaveContext.timerState == TIMER_STATE_UP_FREEZE) && pauseCtx->state == PAUSE_STATE_OFF)
         dpad_y += 15;
 
-    if (gSaveContext.save.info.playerData.dpadDualSet)
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[0]);
-    else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 192, 192, 192, dpadAlphas[0]);
-    gDPLoadTextureBlock(OVERLAY_DISP++, gDpadTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-    gSPTextureRectangle(OVERLAY_DISP++, (dpad_x) << 2, (dpad_y) << 2, (dpad_x + 16) << 2, (dpad_y + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
+    if (Interface_GetItemFromDpad(0) != ITEM_NONE || Interface_GetItemFromDpad(1) != ITEM_NONE || Interface_GetItemFromDpad(2) != ITEM_NONE || Interface_GetItemFromDpad(3) != ITEM_NONE) {
+        if (gSaveContext.save.info.playerData.dpadDualSet)
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlphas[0]);
+        else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 192, 192, 192, dpadAlphas[0]);
+        gDPLoadTextureBlock(OVERLAY_DISP++, gDpadTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+        gSPTextureRectangle(OVERLAY_DISP++, (dpad_x) << 2, (dpad_y) << 2, (dpad_x + 16) << 2, (dpad_y + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
+    }
 
     // B Button Color & Texture
     // Also loads the Item Button Texture reused by other buttons afterwards
@@ -3267,10 +3274,6 @@ void Interface_DrawItemIconTexture(PlayState* play, void* texture, s16 button) {
         }
         
         item = Interface_GetItemFromDpad(button-4);
-        if ( (DPAD_BUTTON(button-4) == SLOT_TUNIC_GORON && !CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON)) || (DPAD_BUTTON(button-4) == SLOT_TUNIC_ZORA  && !CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA)) ||
-             (DPAD_BUTTON(button-4) == SLOT_BOOTS_IRON  && !CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON))  || (DPAD_BUTTON(button-4) == SLOT_BOOTS_HOVER && !CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER)) )
-            return;
-        
         if ( (item == ITEM_TUNIC_GORON && player->currentTunic == 1) || (item == ITEM_TUNIC_ZORA && player->currentTunic == 2) || (item == ITEM_BOOTS_IRON && player->currentBoots == 1) || (item == ITEM_BOOTS_HOVER && player->currentBoots == 2) || (item >= ITEM_MASK_KEATON && item <= ITEM_MASK_TRUTH && player->currentMask == item - ITEM_MASK_KEATON + 1) ) {
             dd    *=  0.8;
             width +=  3;

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1069,7 +1069,7 @@ void func_80083108(PlayState* play) {
                         }
                     }
                     for (i=0; i<4; i++)
-                        if (Interface_GetItemFromDpad(i) >= ITEM_WEIRD_EGG || Interface_GetItemFromDpad(i) <= ITEM_CLAIM_CHECK) {
+                        if (Interface_GetItemFromDpad(i) >= ITEM_WEIRD_EGG && Interface_GetItemFromDpad(i) <= ITEM_CLAIM_CHECK) {
                             if (dpadStatus[i] == BTN_ENABLED)
                                 sp28 = true;
                             dpadStatus[i] = BTN_DISABLED;

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -47,7 +47,6 @@
 #include "z64player.h"
 #include "z64save.h"
 #include "z64vis.h"
-#include "z64interface.h"
 
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ique-cn:224" \
                                "ntsc-1.0:240 ntsc-1.1:240 ntsc-1.2:240 pal-1.0:240 pal-1.1:240"
@@ -497,7 +496,6 @@ void Play_Init(GameState* thisx) {
     player = GET_PLAYER(this);
     Camera_InitDataUsingPlayer(&this->mainCamera, player);
     Camera_RequestMode(&this->mainCamera, CAM_MODE_NORMAL);
-    ItemIcons_Init(this, player);
 
     playerStartBgCamIndex = PLAYER_GET_START_BG_CAM_INDEX(&player->actor);
 

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -47,6 +47,7 @@
 #include "z64player.h"
 #include "z64save.h"
 #include "z64vis.h"
+#include "z64interface.h"
 
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ique-cn:224" \
                                "ntsc-1.0:240 ntsc-1.1:240 ntsc-1.2:240 pal-1.0:240 pal-1.1:240"
@@ -496,6 +497,7 @@ void Play_Init(GameState* thisx) {
     player = GET_PLAYER(this);
     Camera_InitDataUsingPlayer(&this->mainCamera, player);
     Camera_RequestMode(&this->mainCamera, CAM_MODE_NORMAL);
+    ItemIcons_Init(this, player);
 
     playerStartBgCamIndex = PLAYER_GET_START_BG_CAM_INDEX(&player->actor);
 

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -832,6 +832,7 @@ Player* Player_UnsetMask(PlayState* play) {
     Player* this = GET_PLAYER(play);
 
     this->currentMask = PLAYER_MASK_NONE;
+    SET_MASK_AGE(this->currentMask);
 
     return this;
 }

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -125,7 +125,13 @@ static SavePlayerData sNewSavePlayerData = {
         0,                                              // equipment
     },                                                  // adultEquips
     0,                                                  // unk_38
-    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },       // unk_3C
+    0,                                                  // dpadDualSet
+    {
+        { SLOT_LENS_OF_TRUTH, SLOT_BOOTS_IRON,  SLOT_OCARINA, SLOT_BOOTS_HOVER }, // dpadItems (set 1 adult)
+        { SLOT_LENS_OF_TRUTH, SLOT_TRADE_CHILD, SLOT_OCARINA, SLOT_DEKU_NUT    }, // dpadItems (set 1 child)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 adult)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 child)
+    },
     SCENE_LINKS_HOUSE,                                  // savedSceneId
 };
 
@@ -273,7 +279,13 @@ static SavePlayerData sDebugSavePlayerData = {
         0,                                              // equipment
     },                                                  // adultEquips
     0,                                                  // unk_38
-    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },       // unk_3C
+    0,                                                  // dpadDualSet
+    {
+        { SLOT_LENS_OF_TRUTH, SLOT_BOOTS_IRON,  SLOT_OCARINA, SLOT_BOOTS_HOVER }, // dpadItems (set 1 adult)
+        { SLOT_LENS_OF_TRUTH, SLOT_TRADE_CHILD, SLOT_OCARINA, SLOT_DEKU_NUT    }, // dpadItems (set 1 child)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 adult)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 child)
+    },
     SCENE_HYRULE_FIELD,                                 // savedSceneId
 };
 

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -127,10 +127,10 @@ static SavePlayerData sNewSavePlayerData = {
     0,                                                  // unk_38
     0,                                                  // dpadDualSet
     {
-        { SLOT_LENS_OF_TRUTH, SLOT_BOOTS_IRON,  SLOT_OCARINA, SLOT_BOOTS_HOVER }, // dpadItems (set 1 adult)
-        { SLOT_LENS_OF_TRUTH, SLOT_TRADE_CHILD, SLOT_OCARINA, SLOT_DEKU_NUT    }, // dpadItems (set 1 child)
-        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 adult)
-        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 child)
+        { SLOT_LENS_OF_TRUTH, SLOT_BOOTS_HOVER, SLOT_OCARINA, SLOT_BOOTS_IRON }, // dpadItems (set 1 adult)
+        { SLOT_LENS_OF_TRUTH, SLOT_TRADE_CHILD, SLOT_OCARINA, SLOT_DEKU_NUT   }, // dpadItems (set 1 child)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS     }, // dpadItems (set 2 adult)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS     }, // dpadItems (set 2 child)
     },
     SCENE_LINKS_HOUSE,                                  // savedSceneId
 };
@@ -281,10 +281,10 @@ static SavePlayerData sDebugSavePlayerData = {
     0,                                                  // unk_38
     0,                                                  // dpadDualSet
     {
-        { SLOT_LENS_OF_TRUTH, SLOT_BOOTS_IRON,  SLOT_OCARINA, SLOT_BOOTS_HOVER }, // dpadItems (set 1 adult)
-        { SLOT_LENS_OF_TRUTH, SLOT_TRADE_CHILD, SLOT_OCARINA, SLOT_DEKU_NUT    }, // dpadItems (set 1 child)
-        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 adult)
-        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS      }, // dpadItems (set 2 child)
+        { SLOT_LENS_OF_TRUTH, SLOT_BOOTS_HOVER, SLOT_OCARINA, SLOT_BOOTS_IRON }, // dpadItems (set 1 adult)
+        { SLOT_LENS_OF_TRUTH, SLOT_TRADE_CHILD, SLOT_OCARINA, SLOT_DEKU_NUT   }, // dpadItems (set 1 child)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS     }, // dpadItems (set 2 adult)
+        { SLOT_SWORDS,        SLOT_BOOTS,       SLOT_SHIELDS, SLOT_TUNICS     }, // dpadItems (set 2 child)
     },
     SCENE_HYRULE_FIELD,                                 // savedSceneId
 };
@@ -622,8 +622,8 @@ void Sram_OpenSave(SramContext* sramCtx) {
     gSaveContext.save.info.playerData.magicLevel = 0;
 
     if (HasDuplicateDpadItems()) {
-        gSaveContext.save.info.playerData.dpadItems[0][1] = SLOT_BOOTS_IRON;
-        gSaveContext.save.info.playerData.dpadItems[0][3] = SLOT_BOOTS_HOVER;
+        gSaveContext.save.info.playerData.dpadItems[0][1] = SLOT_BOOTS_HOVER;
+        gSaveContext.save.info.playerData.dpadItems[0][3] = SLOT_BOOTS_IRON;
         
         gSaveContext.save.info.playerData.dpadItems[1][1] = SLOT_TRADE_CHILD;
         gSaveContext.save.info.playerData.dpadItems[1][3] = SLOT_DEKU_NUT;

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -437,6 +437,17 @@ static s16 sDungeonEntrances[] = {
     ENTR_INSIDE_GANONS_CASTLE_COLLAPSE_0,  // SCENE_INSIDE_GANONS_CASTLE_COLLAPSE
 };
 
+u8 HasDuplicateDpadItems() {
+    u8 col, i, j;
+
+    for (col=0; col<4; col++)
+        for (i=0; i<4; i++)
+            for (j=i+1; j<4; j++)
+                if (gSaveContext.save.info.playerData.dpadItems[i][col] == gSaveContext.save.info.playerData.dpadItems[j][col])
+                    return true;
+    return false;
+}
+
 /**
  *  Copy save currently on the buffer to Save Context and complete various tasks to open the save.
  *  This includes:
@@ -609,6 +620,22 @@ void Sram_OpenSave(SramContext* sramCtx) {
     }
 
     gSaveContext.save.info.playerData.magicLevel = 0;
+
+    if (HasDuplicateDpadItems()) {
+        gSaveContext.save.info.playerData.dpadItems[0][1] = SLOT_BOOTS_IRON;
+        gSaveContext.save.info.playerData.dpadItems[0][3] = SLOT_BOOTS_HOVER;
+        
+        gSaveContext.save.info.playerData.dpadItems[1][1] = SLOT_TRADE_CHILD;
+        gSaveContext.save.info.playerData.dpadItems[1][3] = SLOT_DEKU_NUT;
+        
+        gSaveContext.save.info.playerData.dpadItems[0][0] = gSaveContext.save.info.playerData.dpadItems[1][0] = SLOT_LENS_OF_TRUTH;
+        gSaveContext.save.info.playerData.dpadItems[0][2] = gSaveContext.save.info.playerData.dpadItems[1][2] = SLOT_OCARINA;
+        
+        gSaveContext.save.info.playerData.dpadItems[2][0] = gSaveContext.save.info.playerData.dpadItems[3][0] = SLOT_SWORDS;
+        gSaveContext.save.info.playerData.dpadItems[2][1] = gSaveContext.save.info.playerData.dpadItems[3][1] = SLOT_BOOTS;
+        gSaveContext.save.info.playerData.dpadItems[2][2] = gSaveContext.save.info.playerData.dpadItems[3][2] = SLOT_SHIELDS;
+        gSaveContext.save.info.playerData.dpadItems[2][3] = gSaveContext.save.info.playerData.dpadItems[3][3] = SLOT_TUNICS;
+    }
 }
 
 /**

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -437,17 +437,6 @@ static s16 sDungeonEntrances[] = {
     ENTR_INSIDE_GANONS_CASTLE_COLLAPSE_0,  // SCENE_INSIDE_GANONS_CASTLE_COLLAPSE
 };
 
-u8 HasDuplicateDpadItems() {
-    u8 col, i, j;
-
-    for (col=0; col<4; col++)
-        for (i=0; i<4; i++)
-            for (j=i+1; j<4; j++)
-                if (gSaveContext.save.info.playerData.dpadItems[i][col] == gSaveContext.save.info.playerData.dpadItems[j][col])
-                    return true;
-    return false;
-}
-
 /**
  *  Copy save currently on the buffer to Save Context and complete various tasks to open the save.
  *  This includes:
@@ -1112,4 +1101,15 @@ void Sram_Alloc(GameState* gameState, SramContext* sramCtx) {
 }
 
 void Sram_Init(GameState* gameState, SramContext* sramCtx) {
+}
+
+u8 HasDuplicateDpadItems(void) {
+    u8 col, i, j;
+
+    for (col=0; col<4; col++)
+        for (i=0; i<4; i++)
+            for (j=i+1; j<4; j++)
+                if (gSaveContext.save.info.playerData.dpadItems[i][col] == gSaveContext.save.info.playerData.dpadItems[j][col])
+                    return true;
+    return false;
 }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2632,6 +2632,8 @@ s32 Player_GetItemOnButton(PlayState* play, s32 index) {
         return C_BTN_ITEM(1);
     } else if (index == 3) {
         return C_BTN_ITEM(2);
+    } else if (sNoclipTimer != 0) {
+        return ITEM_NONE; 
     } else if (index == 4) {
         return D_BTN_ITEM(0);
     } else if (index == 5) {
@@ -14698,11 +14700,15 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
 s32 Player_UpdateNoclip(Player* this, PlayState* play) {
     sControlInput = &play->state.input[0];
 
+    if (sNoclipTimer > 0 && !sNoclipEnabled)
+        sNoclipTimer--;
+
     if ((CHECK_BTN_ALL(sControlInput->cur.button, BTN_A | BTN_L | BTN_R) &&
          CHECK_BTN_ALL(sControlInput->press.button, BTN_B)) ||
         (CHECK_BTN_ALL(sControlInput->cur.button, BTN_L) && CHECK_BTN_ALL(sControlInput->press.button, BTN_DRIGHT))) {
 
         sNoclipEnabled ^= 1;
+        sNoclipTimer = 60 / R_UPDATE_RATE / 4;
 
         if (sNoclipEnabled) {
             Camera_RequestMode(Play_GetCamera(play, CAM_ID_MAIN), CAM_MODE_Z_AIM);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2633,13 +2633,13 @@ s32 Player_GetItemOnButton(PlayState* play, s32 index) {
     } else if (index == 3) {
         return C_BTN_ITEM(2);
     } else if (index == 4) {
-        return Interface_GetItemFromDpad(0);
+        return D_BTN_ITEM(0);
     } else if (index == 5) {
-        return Interface_GetItemFromDpad(1);
+        return D_BTN_ITEM(1);
     } else if (index == 6) {
-        return Interface_GetItemFromDpad(2);
+        return D_BTN_ITEM(2);
     } else {
-        return Interface_GetItemFromDpad(3);
+        return D_BTN_ITEM(3);
     }
 }
 
@@ -2671,6 +2671,7 @@ void Player_ChangeSword(Player* this, PlayState* play, s32 button) {
     
     if (current != this->currentSwordItemId) {
         gSaveContext.save.info.equips.buttonItems[0] = this->currentSwordItemId;
+        Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, this->currentSwordItemId == ITEM_GIANTS_KNIFE ? EQUIP_INV_SWORD_BROKENGIANTKNIFE : this->currentSwordItemId - ITEM_SWORD_KOKIRI + 1);
         Interface_LoadItemIcon1(play, 0);
         Player_ChangeEquipment(this, play, button);
     }
@@ -2693,8 +2694,10 @@ void Player_ChangeShield(Player* this, PlayState* play, s32 button) {
     if (this->currentShield > 3)
         this->currentShield = LINK_IS_CHILD ? 1 : 2;
     
-    if (current != this->currentShield)
+    if (current != this->currentShield) {
+        Inventory_ChangeEquipment(EQUIP_TYPE_SHIELD, this->currentShield);
         Player_ChangeEquipment(this, play, button);
+    }
 }
 
 void Player_ChangeTunic(Player* this, PlayState* play, s32 button) {
@@ -2714,8 +2717,10 @@ void Player_ChangeTunic(Player* this, PlayState* play, s32 button) {
     if (this->currentTunic > 2)
         this->currentTunic = 0;
     
-    if (current != this->currentTunic)
+    if (current != this->currentTunic) {
+        Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, this->currentTunic + 1);
         Player_ChangeEquipment(this, play, button);
+    }
 }
 
 void Player_ChangeBoots(Player* this, PlayState* play, u8 button) {
@@ -2737,6 +2742,7 @@ void Player_ChangeBoots(Player* this, PlayState* play, u8 button) {
     
     if (current != this->currentBoots) {
         Player_SetBootData(play, this);
+        Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, this->currentBoots + 1);
         Player_ChangeEquipment(this, play, button);
     }
 }
@@ -2810,23 +2816,27 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
         else if (item == ITEM_TUNIC_GORON) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_TUNIC_GORON)) {
                 this->currentTunic = this->currentTunic == 1 ? 0 : 1;
+                Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, this->currentTunic + 1);
                 Player_ChangeEquipment(this, play, i);
             }
         } else if (item == ITEM_TUNIC_ZORA) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_TUNIC_ZORA)) {
                 this->currentTunic = this->currentTunic == 2 ? 0 : 2;
+                Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, this->currentTunic + 1);
                 Player_ChangeEquipment(this, play, i);
             }
         } else if (item == ITEM_BOOTS_IRON) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON)) {
                 this->currentBoots = this->currentBoots == 1 ? 0 : 1;
                 Player_SetBootData(play, this);
+                Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, this->currentBoots + 1);
                 Player_ChangeEquipment(this, play, i);
             }
         } else if (item == ITEM_BOOTS_HOVER) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER)) {
                 this->currentBoots = this->currentBoots == 2 ? 0 : 2;
                 Player_SetBootData(play, this);
+                Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, this->currentBoots + 1);
                 Player_ChangeEquipment(this, play, i);
             }
         } else {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3070,7 +3070,7 @@ s32 func_80834758(PlayState* play, Player* this) {
     if (!(this->stateFlags1 & (PLAYER_STATE1_SHIELDING | PLAYER_STATE1_23 | PLAYER_STATE1_29)) &&
         (play->shootingGalleryStatus == 0) && (this->heldItemAction == this->itemAction) &&
         (this->currentShield != PLAYER_SHIELD_NONE) && !Player_IsChildWithHylianShield(this) &&
-        Player_IsZTargeting(this) && CHECK_BTN_ALL(sControlInput->cur.button, BTN_R)) {
+        Player_IsZTargeting(this) && CHECK_BTN_ALL(sControlInput->cur.button, BTN_R) && !CHECK_BTN_ALL(sControlInput->cur.button, BTN_L)) {
 
         anim = func_808346C4(play, this);
         frame = Animation_GetLastFrame(anim);
@@ -3165,7 +3165,7 @@ s32 Player_UpperAction_ChangeHeldItem(Player* this, PlayState* play) {
 s32 func_80834B5C(Player* this, PlayState* play) {
     LinkAnimation_Update(play, &this->upperSkelAnime);
 
-    if (!CHECK_BTN_ALL(sControlInput->cur.button, BTN_R)) {
+    if (!CHECK_BTN_ALL(sControlInput->cur.button, BTN_R) || CHECK_BTN_ALL(sControlInput->cur.button, BTN_L)) {
         func_80834894(this);
         return true;
     } else {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2735,8 +2735,10 @@ void Player_ChangeBoots(Player* this, PlayState* play, u8 button) {
     if (this->currentBoots > 2)
         this->currentBoots = 0;
     
-    if (current != this->currentBoots)
+    if (current != this->currentBoots) {
+        Player_SetBootData(play, this);
         Player_ChangeEquipment(this, play, button);
+    }
 }
 
 /**
@@ -2802,12 +2804,14 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
         else if (item == ITEM_BOOTS_IRON) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON)) {
                 this->currentBoots = this->currentBoots == 1 ? 0 : 1;
+                Player_SetBootData(play, this);
                 Player_ChangeEquipment(this, play, i);
             }
         }
         else if (item == ITEM_BOOTS_HOVER) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER)) {
                 this->currentBoots = this->currentBoots == 2 ? 0 : 2;
+                Player_SetBootData(play, this);
                 Player_ChangeEquipment(this, play, i);
             }
         }
@@ -3673,10 +3677,7 @@ void Player_UseItem(PlayState* play, Player* this, s32 item) {
           (itemAction == PLAYER_IA_NONE))) ||
         ((this->itemAction < 0) && ((Player_ActionToMeleeWeapon(itemAction) != 0) || (itemAction == PLAYER_IA_NONE)))) {
 
-        if ((itemAction == PLAYER_IA_NONE) || !(this->stateFlags1 & PLAYER_STATE1_27) ||
-            ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) &&
-             ((itemAction == PLAYER_IA_HOOKSHOT) || (itemAction == PLAYER_IA_LONGSHOT)))) {
-
+        if (itemAction == PLAYER_IA_NONE || !(this->stateFlags1 & PLAYER_STATE1_27) || ( (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (itemAction == PLAYER_IA_HOOKSHOT || itemAction == PLAYER_IA_LONGSHOT) ) || ( (this->actor.bgCheckFlags & BGCHECKFLAG_WATER) && itemAction >= PLAYER_IA_MASK_KEATON && itemAction <= PLAYER_IA_MASK_TRUTH) ) {
             if ((play->bombchuBowlingStatus == 0) &&
                 (((itemAction == PLAYER_IA_DEKU_STICK) && (AMMO(ITEM_DEKU_STICK) == 0)) ||
                  ((itemAction == PLAYER_IA_MAGIC_BEAN) && (AMMO(ITEM_MAGIC_BEAN) == 0)) ||

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2765,6 +2765,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
             !Player_ItemIsItemAction(C_BTN_ITEM(2), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(0), maskItemAction) &&
             !Player_ItemIsItemAction(Interface_GetItemFromDpad(1), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(2), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(3), maskItemAction) ) {
             this->currentMask = PLAYER_MASK_NONE;
+            SET_MASK_AGE(this->currentMask);
         }
     }
 
@@ -3729,6 +3730,7 @@ void Player_UseItem(PlayState* play, Player* this, s32 item) {
                 } else {
                     this->currentMask = itemAction - PLAYER_IA_MASK_KEATON + 1;
                 }
+                SET_MASK_AGE(this->currentMask);
 
                 func_808328EC(this, NA_SE_PL_CHANGE_ARMS);
             } else if (((itemAction >= PLAYER_IA_OCARINA_FAIRY) && (itemAction <= PLAYER_IA_OCARINA_OF_TIME)) ||

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2647,114 +2647,124 @@ s32 Player_GetItemOnButton(PlayState* play, s32 index) {
 
 void Player_ChangeEquipment(Player* this, PlayState* play, s32 button) {
     u8 i;
-    
+
     if (button < 4) {
         for (i=0; i<4; i++)
             if (Interface_GetItemFromDpad(i) == gSaveContext.save.info.equips.buttonItems[button])
-                Interface_LoadItemIconDpad(play, i);
+                Interface_LoadItemIcon1(play, i+4);
         Interface_LoadItemIcon1(play, button);
     } else {
         for (i=1; i<4; i++)
             if (gSaveContext.save.info.equips.buttonItems[i] == Interface_GetItemFromDpad(button-4))
                 Interface_LoadItemIcon1(play, i);
-        Interface_LoadItemIconDpad(play, button-4);
+        Interface_LoadItemIcon1(play, button);
     }
+
+    Player_SetEquipmentData(play, this);
     Player_PlaySfx(this, NA_SE_PL_CHANGE_ARMS);
 }
 
 void Player_ChangeSword(Player* this, PlayState* play, s32 button) {
-    u8 current = this->currentSwordItemId;
-    
+    u8 current = gSaveContext.save.info.equips.buttonItems[0];
+    u8 new     = current;
+ 
     if (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_KOKIRI) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_BIGGORON))
         return;
     
-    this->currentSwordItemId++;
-    if (this->currentSwordItemId == ITEM_SWORD_KOKIRI   && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_KOKIRI)   || !LINK_IS_CHILD))
-        this->currentSwordItemId++;
-    if (this->currentSwordItemId == ITEM_SWORD_MASTER   && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER)   || !LINK_IS_ADULT))
-        this->currentSwordItemId++;
-    if (this->currentSwordItemId == ITEM_SWORD_BIGGORON && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_BIGGORON) || !LINK_IS_ADULT))
-        this->currentSwordItemId++;
-    
-    if (this->currentSwordItemId > ITEM_SWORD_BIGGORON)
-        this->currentSwordItemId = LINK_IS_CHILD ? ITEM_SWORD_KOKIRI : ITEM_SWORD_MASTER;
-    if (CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_BROKENGIANTKNIFE) && this->currentSwordItemId == ITEM_SWORD_BIGGORON)
-        this->currentSwordItemId = ITEM_GIANTS_KNIFE;
-    
-    if (current != this->currentSwordItemId) {
-        gSaveContext.save.info.equips.buttonItems[0] = this->currentSwordItemId;
-        Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, this->currentSwordItemId == ITEM_GIANTS_KNIFE ? EQUIP_INV_SWORD_BROKENGIANTKNIFE : this->currentSwordItemId - ITEM_SWORD_KOKIRI + 1);
+    if (new != ITEM_SWORD_KOKIRI && new != ITEM_SWORD_MASTER && new != ITEM_SWORD_BIGGORON && new != ITEM_GIANTS_KNIFE)
+        new = ITEM_SWORD_KOKIRI;
+
+    new++;
+    if (new == ITEM_SWORD_KOKIRI   && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_KOKIRI)   || !LINK_IS_CHILD))
+        new++;
+    if (new == ITEM_SWORD_MASTER   && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER)   || !LINK_IS_ADULT))
+        new++;
+    if (new == ITEM_SWORD_BIGGORON && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_BIGGORON) || !LINK_IS_ADULT))
+        new++;
+
+    if (new > ITEM_SWORD_BIGGORON)
+        new = LINK_IS_CHILD ? ITEM_SWORD_KOKIRI : ITEM_SWORD_MASTER;
+    if (CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_BROKENGIANTKNIFE) && new == ITEM_SWORD_BIGGORON)
+        new = ITEM_GIANTS_KNIFE;
+
+    if (current != new) {
+        gSaveContext.save.info.equips.buttonItems[0] = new;
+        Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, new == ITEM_GIANTS_KNIFE ? EQUIP_INV_SWORD_BROKENGIANTKNIFE : new - ITEM_SWORD_KOKIRI + 1);
         Interface_LoadItemIcon1(play, 0);
         Player_ChangeEquipment(this, play, button);
     }
 }
 
 void Player_ChangeShield(Player* this, PlayState* play, s32 button) {
-    u8 current = this->currentShield;
-    
+    u8 current = SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD));
+    u8 new     = current;
+
     if (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_DEKU) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_HYLIAN) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_MIRROR))
         return;
-    
-    this->currentShield++;
-    if (this->currentShield == 1 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_DEKU)   || !LINK_IS_CHILD))
-        this->currentShield++;
-    if (this->currentShield == 2 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_HYLIAN)))
-        this->currentShield++;
-    if (this->currentShield == 3 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_MIRROR) || !LINK_IS_ADULT))
-        this->currentShield++;
-    
-    if (this->currentShield > 3)
-        this->currentShield = LINK_IS_CHILD ? 1 : 2;
-    
-    if (current != this->currentShield) {
-        Inventory_ChangeEquipment(EQUIP_TYPE_SHIELD, this->currentShield);
+
+    new++;
+    if (new == PLAYER_SHIELD_DEKU   && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_DEKU)   || !LINK_IS_CHILD))
+        new++;
+    if (new == PLAYER_SHIELD_HYLIAN && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_HYLIAN)))
+        new++;
+    if (new == PLAYER_SHIELD_MIRROR && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_SHIELD, EQUIP_INV_SHIELD_MIRROR) || !LINK_IS_ADULT))
+        new++;
+
+    if (new > PLAYER_SHIELD_MIRROR)
+        new = LINK_IS_CHILD ? PLAYER_SHIELD_DEKU : PLAYER_SHIELD_HYLIAN;
+
+    if (LINK_IS_CHILD && new == PLAYER_SHIELD_HYLIAN  && (this->stateFlags1 & PLAYER_STATE1_SHIELDING))
+        new = current;
+    else if (current != new) {
+        Inventory_ChangeEquipment(EQUIP_TYPE_SHIELD, new);
         Player_ChangeEquipment(this, play, button);
     }
 }
 
 void Player_ChangeTunic(Player* this, PlayState* play, s32 button) {
-    u8 current = this->currentTunic;
-    
+    u8 current = TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC));
+    u8 new     = current;
+
     if (!CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_KOKIRI) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA))
         return;
-    
-    this->currentTunic++;
-    if (this->currentTunic == 0 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_KOKIRI)))
-        this->currentTunic++;
-    if (this->currentTunic == 1 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON) || !LINK_IS_ADULT))
-        this->currentTunic++;
-    if (this->currentTunic == 2 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA)  || !LINK_IS_ADULT))
-        this->currentTunic++;
-    
-    if (this->currentTunic > 2)
-        this->currentTunic = 0;
-    
-    if (current != this->currentTunic) {
-        Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, this->currentTunic + 1);
+
+    new++;
+    if (new == 0 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_KOKIRI)))
+        new++;
+    if (new == 1 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON) || !LINK_IS_ADULT))
+        new++;
+    if (new == 2 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA)  || !LINK_IS_ADULT))
+        new++;
+
+    if (new > 2)
+        new = 0;
+
+    if (current != new) {
+        Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, new + 1);
         Player_ChangeEquipment(this, play, button);
     }
 }
 
 void Player_ChangeBoots(Player* this, PlayState* play, u8 button) {
-    u8 current = this->currentBoots;
+    u8 current = BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS));
+    u8 new     = current;
     
     if (!CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_KOKIRI) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER))
         return;
     
-    this->currentBoots++;
-    if (this->currentBoots == 0 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_KOKIRI)))
-        this->currentBoots++;
-    if (this->currentBoots == 1 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON)  || !LINK_IS_ADULT))
-        this->currentBoots++;
-    if (this->currentBoots == 2 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER) || !LINK_IS_ADULT))
-        this->currentBoots++;
+    new++;
+    if (new == 0 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_KOKIRI)))
+        new++;
+    if (new == 1 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON)  || !LINK_IS_ADULT))
+        new++;
+    if (new == 2 && (!CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER) || !LINK_IS_ADULT))
+        new++;
     
-    if (this->currentBoots > 2)
-        this->currentBoots = 0;
+    if (new > 2)
+        new = 0;
     
-    if (current != this->currentBoots) {
-        Player_SetBootData(play, this);
-        Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, this->currentBoots + 1);
+    if (current != new) {
+        Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, new + 1);
         Player_ChangeEquipment(this, play, button);
     }
 }
@@ -2832,7 +2842,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 Player_ChangeEquipment(this, play, i);
                 for (i=0; i<4; i++) {
                     if (Interface_GetItemFromDpad(i) == ITEM_TUNICS)
-                        Interface_LoadItemIconDpad(play, i);
+                        Interface_LoadItemIcon1(play, i+4);
                     if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_TUNICS)
                         Interface_LoadItemIcon1(play, i);
                 }
@@ -2844,7 +2854,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 Player_ChangeEquipment(this, play, i);
                 for (i=0; i<4; i++) {
                     if (Interface_GetItemFromDpad(i) == ITEM_TUNICS)
-                        Interface_LoadItemIconDpad(play, i);
+                        Interface_LoadItemIcon1(play, i+4);
                     if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_TUNICS)
                         Interface_LoadItemIcon1(play, i);
                 }
@@ -2857,7 +2867,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 Player_ChangeEquipment(this, play, i);
                 for (i=0; i<4; i++) {
                     if (Interface_GetItemFromDpad(i) == ITEM_BOOTS)
-                        Interface_LoadItemIconDpad(play, i);
+                        Interface_LoadItemIcon1(play, i+4);
                     if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_BOOTS)
                         Interface_LoadItemIcon1(play, i);
                 }
@@ -2870,7 +2880,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 Player_ChangeEquipment(this, play, i);
                 for (i=0; i<4; i++) {
                     if (Interface_GetItemFromDpad(i) == ITEM_BOOTS)
-                        Interface_LoadItemIconDpad(play, i);
+                        Interface_LoadItemIcon1(play, i+4);
                     if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_BOOTS)
                         Interface_LoadItemIcon1(play, i);
                 }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2644,9 +2644,19 @@ s32 Player_GetItemOnButton(PlayState* play, s32 index) {
 }
 
 void Player_ChangeEquipment(Player* this, PlayState* play, s32 button) {
-    if (button < 4)
+    u8 i;
+    
+    if (button < 4) {
+        for (i=0; i<4; i++)
+            if (Interface_GetItemFromDpad(i) == gSaveContext.save.info.equips.buttonItems[button])
+                Interface_LoadItemIconDpad(play, i);
         Interface_LoadItemIcon1(play, button);
-    else Interface_LoadItemIconDpad(play, button-4);
+    } else {
+        for (i=1; i<4; i++)
+            if (gSaveContext.save.info.equips.buttonItems[i] == Interface_GetItemFromDpad(button-4))
+                Interface_LoadItemIcon1(play, i);
+        Interface_LoadItemIconDpad(play, button-4);
+    }
     Player_PlaySfx(this, NA_SE_PL_CHANGE_ARMS);
 }
 
@@ -2818,12 +2828,24 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 this->currentTunic = this->currentTunic == 1 ? 0 : 1;
                 Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, this->currentTunic + 1);
                 Player_ChangeEquipment(this, play, i);
+                for (i=0; i<4; i++) {
+                    if (Interface_GetItemFromDpad(i) == ITEM_TUNICS)
+                        Interface_LoadItemIconDpad(play, i);
+                    if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_TUNICS)
+                        Interface_LoadItemIcon1(play, i);
+                }
             }
         } else if (item == ITEM_TUNIC_ZORA) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_TUNIC_ZORA)) {
                 this->currentTunic = this->currentTunic == 2 ? 0 : 2;
                 Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, this->currentTunic + 1);
                 Player_ChangeEquipment(this, play, i);
+                for (i=0; i<4; i++) {
+                    if (Interface_GetItemFromDpad(i) == ITEM_TUNICS)
+                        Interface_LoadItemIconDpad(play, i);
+                    if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_TUNICS)
+                        Interface_LoadItemIcon1(play, i);
+                }
             }
         } else if (item == ITEM_BOOTS_IRON) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON)) {
@@ -2831,6 +2853,12 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 Player_SetBootData(play, this);
                 Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, this->currentBoots + 1);
                 Player_ChangeEquipment(this, play, i);
+                for (i=0; i<4; i++) {
+                    if (Interface_GetItemFromDpad(i) == ITEM_BOOTS)
+                        Interface_LoadItemIconDpad(play, i);
+                    if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_BOOTS)
+                        Interface_LoadItemIcon1(play, i);
+                }
             }
         } else if (item == ITEM_BOOTS_HOVER) {
             if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER)) {
@@ -2838,6 +2866,12 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 Player_SetBootData(play, this);
                 Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, this->currentBoots + 1);
                 Player_ChangeEquipment(this, play, i);
+                for (i=0; i<4; i++) {
+                    if (Interface_GetItemFromDpad(i) == ITEM_BOOTS)
+                        Interface_LoadItemIconDpad(play, i);
+                    if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_BOOTS)
+                        Interface_LoadItemIcon1(play, i);
+                }
             }
         } else {
             this->heldItemButton = i;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1928,7 +1928,7 @@ void FileSelect_LoadGame(GameState* thisx) {
     gSaveContext.retainWeatherMode = false;
 
     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
 
     gSaveContext.forceRisingButtonAlphas = gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode =
         gSaveContext.hudVisibilityModeTimer = gSaveContext.magicCapacity = 0; // false, HUD_VISIBILITY_NO_CHANGE
@@ -2316,7 +2316,7 @@ void FileSelect_InitContext(GameState* thisx) {
     Environment_UpdateSkybox(SKYBOX_NORMAL_SKY, &this->envCtx, &this->skyboxCtx);
 
     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
 
     this->n64ddFlags[0] = this->n64ddFlags[1] = this->n64ddFlags[2] = this->defense[0] = this->defense[1] =
         this->defense[2] = 0;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1928,7 +1928,8 @@ void FileSelect_LoadGame(GameState* thisx) {
     gSaveContext.retainWeatherMode = false;
 
     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+    dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
 
     gSaveContext.forceRisingButtonAlphas = gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode =
         gSaveContext.hudVisibilityModeTimer = gSaveContext.magicCapacity = 0; // false, HUD_VISIBILITY_NO_CHANGE
@@ -2316,7 +2317,8 @@ void FileSelect_InitContext(GameState* thisx) {
     Environment_UpdateSkybox(SKYBOX_NORMAL_SKY, &this->envCtx, &this->skyboxCtx);
 
     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+    dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
 
     this->n64ddFlags[0] = this->n64ddFlags[1] = this->n64ddFlags[2] = this->defense[0] = this->defense[1] =
         this->defense[2] = 0;

--- a/src/overlays/gamestates/ovl_select/z_select.c
+++ b/src/overlays/gamestates/ovl_select/z_select.c
@@ -48,7 +48,8 @@ void MapSelect_LoadGame(MapSelectState* this, s32 entranceIndex) {
         gSaveContext.save.info.playerData.magicLevel = gSaveContext.save.info.playerData.magic = 0;
     }
     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+    dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
     gSaveContext.forceRisingButtonAlphas = gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode =
         gSaveContext.hudVisibilityModeTimer = 0; // false, HUD_VISIBILITY_NO_CHANGE
     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0);

--- a/src/overlays/gamestates/ovl_select/z_select.c
+++ b/src/overlays/gamestates/ovl_select/z_select.c
@@ -48,7 +48,7 @@ void MapSelect_LoadGame(MapSelectState* this, s32 entranceIndex) {
         gSaveContext.save.info.playerData.magicLevel = gSaveContext.save.info.playerData.magic = 0;
     }
     gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
-        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+        gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
     gSaveContext.forceRisingButtonAlphas = gSaveContext.nextHudVisibilityMode = gSaveContext.hudVisibilityMode =
         gSaveContext.hudVisibilityModeTimer = 0; // false, HUD_VISIBILITY_NO_CHANGE
     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0);

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
@@ -562,8 +562,8 @@ void KaleidoScope_DrawDebugEditor(PlayState* play) {
                     }
                 }
                 if (CHECK_BTN_ANY(input->press.button, BTN_CUP | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT))
-                    for (j=0; j<4; j++)
-                        Interface_LoadItemIconDpad(play, j);
+                    for (j=4; j<8; j++)
+                        Interface_LoadItemIcon1(play, j);
             } else if (curSection < 0x2C) {
                 if (CHECK_BTN_ALL(input->press.button, BTN_CUP) || CHECK_BTN_ALL(input->press.button, BTN_CLEFT)) {
                     i = curSection - 0x1B;
@@ -614,8 +614,8 @@ void KaleidoScope_DrawDebugEditor(PlayState* play) {
                         }
                     }
                     if (CHECK_BTN_ANY(input->press.button, BTN_CUP | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT))
-                        for (j=0; j<4; j++)
-                            Interface_LoadItemIconDpad(play, j);
+                        for (j=4; j<8; j++)
+                            Interface_LoadItemIcon1(play, j);
                 } else if (curSection < 0x44) {
                     i = curSection - 0x38;
                     if (CHECK_BTN_ALL(input->press.button, BTN_CLEFT)) {

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
@@ -561,6 +561,9 @@ void KaleidoScope_DrawDebugEditor(PlayState* play) {
                         }
                     }
                 }
+                if (CHECK_BTN_ANY(input->press.button, BTN_CUP | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT))
+                    for (j=0; j<4; j++)
+                        Interface_LoadItemIconDpad(play, j);
             } else if (curSection < 0x2C) {
                 if (CHECK_BTN_ALL(input->press.button, BTN_CUP) || CHECK_BTN_ALL(input->press.button, BTN_CLEFT)) {
                     i = curSection - 0x1B;
@@ -610,6 +613,9 @@ void KaleidoScope_DrawDebugEditor(PlayState* play) {
                             gSaveContext.save.info.inventory.equipment ^= OWNED_EQUIP_FLAG_ALT(i, 3);
                         }
                     }
+                    if (CHECK_BTN_ANY(input->press.button, BTN_CUP | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT))
+                        for (j=0; j<4; j++)
+                            Interface_LoadItemIconDpad(play, j);
                 } else if (curSection < 0x44) {
                     i = curSection - 0x38;
                     if (CHECK_BTN_ALL(input->press.button, BTN_CLEFT)) {

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
@@ -673,7 +673,7 @@ void KaleidoScope_DrawDebugEditor(PlayState* play) {
     // The editor is opened with `debugState` set to 1, and becomes closable after a frame once `debugState` is set to 2
     if (pauseCtx->debugState == 1) {
         pauseCtx->debugState = 2;
-    } else if ((pauseCtx->debugState == 2) && CHECK_BTN_ALL(input->press.button, BTN_L)) {
+    } else if ((pauseCtx->debugState == 2) && CHECK_BTN_ALL(input->rel.button, BTN_L)) {
         pauseCtx->debugState = 0;
     }
 

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -506,7 +506,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                     }
                     else {
                         if (Interface_GetItemFromDpad(i-4) == ITEM_SWORDS || Interface_GetItemFromDpad(i-4) == ITEM_SHIELDS || Interface_GetItemFromDpad(i-4) == ITEM_TUNICS || Interface_GetItemFromDpad(i-4) == ITEM_BOOTS)
-                            Interface_LoadItemIconDpad(play, i-4);
+                            Interface_LoadItemIcon1(play, i);
                     }
                 }
 
@@ -527,16 +527,12 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                     temp = SLOT_SHIELDS;
                 else if (cursorSlot == 9)
                     temp = SLOT_TUNICS;
-                else if (cursorSlot == 10)
-                    temp = SLOT_TUNIC_GORON;
-                else if (cursorSlot == 11)
-                    temp = SLOT_TUNIC_ZORA;
+                else if (cursorSlot == 10 || cursorSlot == 11)
+                    temp = SLOT_TUNIC_GORON + cursorSlot - 10;
                 else if (cursorSlot == 13)
                     temp = SLOT_BOOTS;
-                else if (cursorSlot == 14)
-                    temp = SLOT_BOOTS_IRON;
-                else if (cursorSlot == 15)
-                    temp = SLOT_BOOTS_HOVER;
+                else if (cursorSlot == 14 || cursorSlot == 15)
+                    temp = SLOT_BOOTS_IRON + cursorSlot - 14;
                 else temp = SLOT_NONE;
                 
                 if (temp != SLOT_NONE) {
@@ -564,17 +560,13 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                             i = 2;
                         else i = 3;
                         
-                        for (j=1; j<4; j++) {
-                            if (j == i)
-                                continue;
-                            
-                            if (gSaveContext.save.info.equips.buttonItems[j] == temp) {
+                        for (j=1; j<4; j++)
+                            if (gSaveContext.save.info.equips.buttonItems[j] == temp && j != i) {
                                 gSaveContext.save.info.equips.buttonItems[j]    = gSaveContext.save.info.equips.buttonItems[i];
                                 gSaveContext.save.info.equips.cButtonSlots[j-1] = gSaveContext.save.info.equips.cButtonSlots[i-1];
                                 Interface_LoadItemIcon1(play, j);
                                 break;
                             }
-                        }
                         
                         gSaveContext.save.info.equips.buttonItems[i]    = temp;
                         gSaveContext.save.info.equips.cButtonSlots[i-1] = SLOT_NONE;
@@ -590,19 +582,15 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                             i = 2;
                         else i = 3;
                         
-                        for (j=0; j<4; j++) {
-                            if (j == i)
-                                continue;
-                            
-                            if (DPAD_BUTTON(j) == temp) {
+                        for (j=0; j<4; j++)
+                            if (DPAD_BUTTON(j) == temp && j != i) {
                                 DPAD_BUTTON(j) = DPAD_BUTTON(i);
-                                Interface_LoadItemIconDpad(play, j);
+                                Interface_LoadItemIcon1(play, j+4);
                                 break;
                             }
-                        }
                         
                         DPAD_BUTTON(i) = temp;
-                        Interface_LoadItemIconDpad(play, i);
+                        Interface_LoadItemIcon1(play, i+4);
                         Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                     }
                 }

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -500,22 +500,14 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                 }
 
                 for (i=1; i<8; i++) {
-                    if (i<4)
-                        item = gSaveContext.save.info.equips.buttonItems[i];
-                    else item = Interface_GetItemFromDpad(i-4);
-
-                    if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && item == ITEM_SWORDS)
-                        item = ITEM_SWORD_KOKIRI + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
-                    else if (pauseCtx->cursorY[PAUSE_EQUIP] == 1 && item == ITEM_SHIELDS)
-                        item = ITEM_SHIELD_DEKU + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
-                    else if (pauseCtx->cursorY[PAUSE_EQUIP] == 2 && item == ITEM_TUNICS)
-                        item = ITEM_TUNIC_KOKIRI + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
-                    else if (pauseCtx->cursorY[PAUSE_EQUIP] == 3 && item == ITEM_BOOTS)
-                        item = ITEM_BOOTS_KOKIRI + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
-                    else item = ITEM_NONE;
-
-                    if (item != ITEM_NONE)
-                        DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
+                    if (i<4) {
+                        if (gSaveContext.save.info.equips.buttonItems[i] == ITEM_SWORDS || gSaveContext.save.info.equips.buttonItems[i] == ITEM_SHIELDS || gSaveContext.save.info.equips.buttonItems[i] == ITEM_TUNICS || gSaveContext.save.info.equips.buttonItems[i] == ITEM_BOOTS)
+                            Interface_LoadItemIcon1(play, i);
+                    }
+                    else {
+                        if (Interface_GetItemFromDpad(i-4) == ITEM_SWORDS || Interface_GetItemFromDpad(i-4) == ITEM_SHIELDS || Interface_GetItemFromDpad(i-4) == ITEM_TUNICS || Interface_GetItemFromDpad(i-4) == ITEM_BOOTS)
+                            Interface_LoadItemIconDpad(play, i-4);
+                    }
                 }
 
                 Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -474,6 +474,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
             CHECK_BTN_ALL(input->press.button, BTN_A) && (pauseCtx->cursorX[PAUSE_EQUIP] != 0)) {
 
             if (CHECK_AGE_REQ_EQUIP(pauseCtx->cursorY[PAUSE_EQUIP], pauseCtx->cursorX[PAUSE_EQUIP])) {
+                u8 item;
                 Inventory_ChangeEquipment(pauseCtx->cursorY[PAUSE_EQUIP], pauseCtx->cursorX[PAUSE_EQUIP]);
 
                 if (pauseCtx->cursorY[PAUSE_EQUIP] == 0) {
@@ -496,6 +497,25 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                     }
 
                     Interface_LoadItemIcon1(play, 0);
+                }
+
+                for (i=1; i<8; i++) {
+                    if (i<4)
+                        item = gSaveContext.save.info.equips.buttonItems[i];
+                    else item = Interface_GetItemFromDpad(i-4);
+
+                    if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && item == ITEM_SWORDS)
+                        item = ITEM_SWORD_KOKIRI + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
+                    else if (pauseCtx->cursorY[PAUSE_EQUIP] == 1 && item == ITEM_SHIELDS)
+                        item = ITEM_SHIELD_DEKU + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
+                    else if (pauseCtx->cursorY[PAUSE_EQUIP] == 2 && item == ITEM_TUNICS)
+                        item = ITEM_TUNIC_KOKIRI + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
+                    else if (pauseCtx->cursorY[PAUSE_EQUIP] == 3 && item == ITEM_BOOTS)
+                        item = ITEM_BOOTS_KOKIRI + pauseCtx->cursorX[PAUSE_EQUIP] - 1;
+                    else item = ITEM_NONE;
+
+                    if (item != ITEM_NONE)
+                        DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (i * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(item), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
                 }
 
                 Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -507,6 +507,96 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
             }
         }
+        if ((pauseCtx->cursorSpecialPos == 0) && (cursorItem != PAUSE_ITEM_NONE) && (pauseCtx->state == PAUSE_STATE_MAIN) && (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE) && CHECK_BTN_ANY(input->press.button, BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT | BTN_DUP | BTN_DRIGHT | BTN_DDOWN | BTN_DLEFT) && (pauseCtx->cursorX[PAUSE_EQUIP] != 0)) {
+            if (CHECK_AGE_REQ_EQUIP(pauseCtx->cursorY[PAUSE_EQUIP], pauseCtx->cursorX[PAUSE_EQUIP])) {
+                if (cursorSlot == 1 || cursorSlot == 2 || cursorSlot == 3)
+                    temp = SLOT_SWORDS;
+                else if (cursorSlot == 5 || cursorSlot == 6 || cursorSlot == 7)
+                    temp = SLOT_SHIELDS;
+                else if (cursorSlot == 9)
+                    temp = SLOT_TUNICS;
+                else if (cursorSlot == 10)
+                    temp = SLOT_TUNIC_GORON;
+                else if (cursorSlot == 11)
+                    temp = SLOT_TUNIC_ZORA;
+                else if (cursorSlot == 13)
+                    temp = SLOT_BOOTS;
+                else if (cursorSlot == 14)
+                    temp = SLOT_BOOTS_IRON;
+                else if (cursorSlot == 15)
+                    temp = SLOT_BOOTS_HOVER;
+                else temp = SLOT_NONE;
+                
+                if (temp != SLOT_NONE) {
+                    if (CHECK_BTN_ANY(input->press.button, BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT)) {
+                        if (temp == SLOT_SWORDS)
+                            temp = ITEM_SWORDS;
+                        else if (temp == SLOT_SHIELDS)
+                            temp = ITEM_SHIELDS;
+                        else if (temp == SLOT_TUNICS)
+                            temp = ITEM_TUNICS;
+                        else if (temp == SLOT_BOOTS)
+                            temp = ITEM_BOOTS;
+                        else if (temp == SLOT_TUNIC_GORON)
+                            temp = ITEM_TUNIC_GORON;
+                        else if (temp == SLOT_TUNIC_ZORA)
+                            temp = ITEM_TUNIC_ZORA;
+                        else if (temp == SLOT_BOOTS_IRON)
+                            temp = ITEM_BOOTS_IRON;
+                        else if (temp == SLOT_BOOTS_HOVER)
+                            temp = ITEM_BOOTS_HOVER;
+                        
+                        if (CHECK_BTN_ALL(input->press.button, BTN_CLEFT))
+                            i = 1;
+                        else if (CHECK_BTN_ALL(input->press.button, BTN_CDOWN))
+                            i = 2;
+                        else i = 3;
+                        
+                        for (j=1; j<4; j++) {
+                            if (j == i)
+                                continue;
+                            
+                            if (gSaveContext.save.info.equips.buttonItems[j] == temp) {
+                                gSaveContext.save.info.equips.buttonItems[j]    = gSaveContext.save.info.equips.buttonItems[i];
+                                gSaveContext.save.info.equips.cButtonSlots[j-1] = gSaveContext.save.info.equips.cButtonSlots[i-1];
+                                Interface_LoadItemIcon1(play, j);
+                                break;
+                            }
+                        }
+                        
+                        gSaveContext.save.info.equips.buttonItems[i]    = temp;
+                        gSaveContext.save.info.equips.cButtonSlots[i-1] = SLOT_NONE;
+                        Interface_LoadItemIcon1(play, i);
+                        Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                    }
+                    else {
+                        if (CHECK_BTN_ALL(input->press.button, BTN_DUP))
+                            i = 0;
+                        else if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))
+                            i = 1;
+                        else if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN))
+                            i = 2;
+                        else i = 3;
+                        
+                        for (j=0; j<4; j++) {
+                            if (j == i)
+                                continue;
+                            
+                            if (DPAD_BUTTON(j) == temp) {
+                                DPAD_BUTTON(j) = DPAD_BUTTON(i);
+                                Interface_LoadItemIconDpad(play, j);
+                                break;
+                            }
+                        }
+                        
+                        DPAD_BUTTON(i) = temp;
+                        Interface_LoadItemIconDpad(play, i);
+                        Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                    }
+                }
+            }
+            else Audio_PlaySfxGeneral(NA_SE_SY_ERROR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        }
 
         if (oldCursorPoint != pauseCtx->cursorPoint[PAUSE_EQUIP]) {
             Audio_PlaySfxGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -431,6 +431,32 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                         }
                     }
+                    else if (CHECK_BTN_ANY(input->press.button, BTN_DUP | BTN_DRIGHT | BTN_DDOWN | BTN_DLEFT)) {
+                        if (CHECK_AGE_REQ_SLOT(cursorSlot) && (cursorItem != ITEM_SOLD_OUT)) {
+                            u8 button;
+                            
+                            if (CHECK_BTN_ALL(input->press.button, BTN_DUP))
+                                button = 0;
+                            else if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))
+                                button = 1;
+                            else if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN))
+                                button = 2;
+                            else button = 3;
+                            
+                            for (i=0; i<4; i++)
+                                if (DPAD_BUTTON(i) == cursorItem) {
+                                    DPAD_BUTTON(i) = DPAD_BUTTON(button);
+                                    Interface_LoadItemIconDpad(play, i);
+                                    break;
+                                }
+                            
+                            DPAD_BUTTON(button) = cursorSlot;
+                            Interface_LoadItemIconDpad(play, button);
+                            Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                        }
+                        else Audio_PlaySfxGeneral(NA_SE_SY_ERROR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                    }
+                    
                 }
             } else {
                 pauseCtx->cursorVtx[0].v.ob[0] = pauseCtx->cursorVtx[2].v.ob[0] = pauseCtx->cursorVtx[1].v.ob[0] =

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -434,7 +434,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                     else if (CHECK_BTN_ANY(input->press.button, BTN_DUP | BTN_DRIGHT | BTN_DDOWN | BTN_DLEFT)) {
                         if (CHECK_AGE_REQ_SLOT(cursorSlot) && (cursorItem != ITEM_SOLD_OUT)) {
                             u8 button;
-                            
+
                             if (CHECK_BTN_ALL(input->press.button, BTN_DUP))
                                 button = 0;
                             else if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))
@@ -442,18 +442,24 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                             else if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN))
                                 button = 2;
                             else button = 3;
-                            
+
                             for (i=0; i<4; i++) {
                                 if (i == button)
                                     continue;
-                            
+
                                 if (DPAD_BUTTON(i) == cursorSlot) {
                                     DPAD_BUTTON(i) = DPAD_BUTTON(button);
                                     Interface_LoadItemIconDpad(play, i);
                                     break;
                                 }
+
+                                if (DPAD_BUTTON(i) == cursorSlot || ((cursorSlot == SLOT_BOW || cursorSlot == SLOT_ARROW_FIRE || cursorSlot == SLOT_ARROW_ICE || cursorSlot == SLOT_ARROW_LIGHT) && (DPAD_BUTTON(i) == SLOT_BOW || DPAD_BUTTON(i) == SLOT_ARROW_FIRE || DPAD_BUTTON(i) == SLOT_ARROW_ICE || DPAD_BUTTON(i) == SLOT_ARROW_LIGHT))) {
+                                    DPAD_BUTTON(i) = DPAD_BUTTON(button);
+                                    Interface_LoadItemIconDpad(play, i);
+                                    break;
+                                }
                             }
-                            
+
                             DPAD_BUTTON(button) = cursorSlot;
                             Interface_LoadItemIconDpad(play, button);
                             Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -443,12 +443,16 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                                 button = 2;
                             else button = 3;
                             
-                            for (i=0; i<4; i++)
-                                if (DPAD_BUTTON(i) == cursorItem) {
+                            for (i=0; i<4; i++) {
+                                if (i == button)
+                                    continue;
+                            
+                                if (DPAD_BUTTON(i) == cursorSlot) {
                                     DPAD_BUTTON(i) = DPAD_BUTTON(button);
                                     Interface_LoadItemIconDpad(play, i);
                                     break;
                                 }
+                            }
                             
                             DPAD_BUTTON(button) = cursorSlot;
                             Interface_LoadItemIconDpad(play, button);
@@ -485,7 +489,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
     gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
 
     for (i = 0, j = ITEM_QUAD_GRID_SELECTED_C_LEFT * 4; i < 3; i++, j += 4) {
-        if (gSaveContext.save.info.equips.buttonItems[i + 1] != ITEM_NONE) {
+        if (gSaveContext.save.info.equips.buttonItems[i + 1] != ITEM_NONE && gSaveContext.save.info.equips.cButtonSlots[i] != SLOT_NONE) {
             gSPVertex(POLY_OPA_DISP++, &pauseCtx->itemVtx[j], 4, 0);
             POLY_OPA_DISP = KaleidoScope_QuadTextureIA8(POLY_OPA_DISP, gEquippedItemOutlineTex, 32, 32, 0);
         }

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -447,21 +447,15 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                                 if (i == button)
                                     continue;
 
-                                if (DPAD_BUTTON(i) == cursorSlot) {
-                                    DPAD_BUTTON(i) = DPAD_BUTTON(button);
-                                    Interface_LoadItemIconDpad(play, i);
-                                    break;
-                                }
-
                                 if (DPAD_BUTTON(i) == cursorSlot || ((cursorSlot == SLOT_BOW || cursorSlot == SLOT_ARROW_FIRE || cursorSlot == SLOT_ARROW_ICE || cursorSlot == SLOT_ARROW_LIGHT) && (DPAD_BUTTON(i) == SLOT_BOW || DPAD_BUTTON(i) == SLOT_ARROW_FIRE || DPAD_BUTTON(i) == SLOT_ARROW_ICE || DPAD_BUTTON(i) == SLOT_ARROW_LIGHT))) {
                                     DPAD_BUTTON(i) = DPAD_BUTTON(button);
-                                    Interface_LoadItemIconDpad(play, i);
+                                    Interface_LoadItemIcon1(play, i+4);
                                     break;
                                 }
                             }
 
                             DPAD_BUTTON(button) = cursorSlot;
-                            Interface_LoadItemIconDpad(play, button);
+                            Interface_LoadItemIcon1(play, button+4);
                             Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                         }
                         else Audio_PlaySfxGeneral(NA_SE_SY_ERROR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -932,7 +932,7 @@ static void* sPromptChoiceTexs[][2] = {
 //! non-static, but we make it static here to match the bss order and patch the relocation section later in the build
 //! as our relocation generator does count COMMON symbols.
 
-static u8 D_808321A8[5];
+static u8 D_808321A8[9];
 static PreRender sPlayerPreRender;
 void* sPreRenderCvg;
 
@@ -3435,6 +3435,7 @@ void KaleidoScope_UpdateOpening(PlayState* play) {
         gSaveContext.buttonStatus[2] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + PAGE_SWITCH_PT_LEFT][2];
         gSaveContext.buttonStatus[3] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + PAGE_SWITCH_PT_LEFT][3];
         gSaveContext.buttonStatus[4] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + PAGE_SWITCH_PT_LEFT][4];
+        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + PAGE_SWITCH_PT_LEFT][1];
 
         pauseCtx->pageIndex = sPageSwitchNextPageIndex[pauseCtx->nextPageMode];
 
@@ -3640,6 +3641,10 @@ void KaleidoScope_Update(PlayState* play) {
             D_808321A8[2] = gSaveContext.buttonStatus[2];
             D_808321A8[3] = gSaveContext.buttonStatus[3];
             D_808321A8[4] = gSaveContext.buttonStatus[4];
+            D_808321A8[5] = dpadStatus[0];
+            D_808321A8[6] = dpadStatus[1];
+            D_808321A8[7] = dpadStatus[2];
+            D_808321A8[8] = dpadStatus[3];
 
             pauseCtx->cursorX[PAUSE_MAP] = 0;
             pauseCtx->cursorSlot[PAUSE_MAP] = pauseCtx->cursorPoint[PAUSE_MAP] = pauseCtx->dungeonMapSlot =
@@ -4062,6 +4067,7 @@ void KaleidoScope_Update(PlayState* play) {
                                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                             gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                         gSaveContext.buttonStatus[4] = BTN_ENABLED;
                         gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
@@ -4110,6 +4116,7 @@ void KaleidoScope_Update(PlayState* play) {
                                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                             gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                         gSaveContext.buttonStatus[4] = BTN_ENABLED;
                         gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
@@ -4164,6 +4171,7 @@ void KaleidoScope_Update(PlayState* play) {
                                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                             gSaveContext.buttonStatus[3] = BTN_DISABLED;
+                        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_DISABLED;
                         gSaveContext.buttonStatus[4] = BTN_ENABLED;
                         gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
@@ -4199,6 +4207,7 @@ void KaleidoScope_Update(PlayState* play) {
                             Interface_SetDoAction(play, DO_ACTION_NONE);
                             gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                                 gSaveContext.buttonStatus[3] = BTN_ENABLED;
+                            dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
                             gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                             Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
                             pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_CLOSING;
@@ -4231,6 +4240,7 @@ void KaleidoScope_Update(PlayState* play) {
                         func_800F64E0(0);
                         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                             gSaveContext.buttonStatus[3] = BTN_ENABLED;
+                        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
                         gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
 #if PLATFORM_GC && OOT_NTSC
@@ -4245,6 +4255,7 @@ void KaleidoScope_Update(PlayState* play) {
                         Interface_SetDoAction(play, DO_ACTION_NONE);
                         gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
                             gSaveContext.buttonStatus[3] = BTN_ENABLED;
+                        dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
                         gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
                         pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_CLOSING_AFTER_SAVED;
@@ -4673,6 +4684,11 @@ void KaleidoScope_Update(PlayState* play) {
             gSaveContext.buttonStatus[2] = D_808321A8[2];
             gSaveContext.buttonStatus[3] = D_808321A8[3];
             gSaveContext.buttonStatus[4] = D_808321A8[4];
+            dpadStatus[0] = D_808321A8[5];
+            dpadStatus[1] = D_808321A8[6];
+            dpadStatus[2] = D_808321A8[7];
+            dpadStatus[3] = D_808321A8[8];
+            
             interfaceCtx->unk_1FA = interfaceCtx->unk_1FC = 0;
             PRINTF_COLOR_YELLOW();
             PRINTF("i=%d  LAST_TIME_TYPE=%d\n", i, gSaveContext.prevHudVisibilityMode);

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -667,7 +667,7 @@ static u8 gPageSwitchNextButtonStatus[][5] = {
     // PAUSE_ITEM  + PAGE_SWITCH_PT_LEFT
     //
     //  -> PAUSE_EQUIP
-    { BTN_ENABLED, BTN_DISABLED, BTN_DISABLED, BTN_DISABLED, BTN_ENABLED },
+    { BTN_ENABLED, BTN_ENABLED, BTN_ENABLED, BTN_ENABLED, BTN_ENABLED },
     // PAUSE_MAP   + PAGE_SWITCH_PT_LEFT
     //
     //  -> PAUSE_ITEM
@@ -683,7 +683,7 @@ static u8 gPageSwitchNextButtonStatus[][5] = {
     //
     // PAUSE_QUEST + PAGE_SWITCH_PT_RIGHT
     //  -> PAUSE_EQUIP
-    { BTN_ENABLED, BTN_DISABLED, BTN_DISABLED, BTN_DISABLED, BTN_ENABLED },
+    { BTN_ENABLED, BTN_ENABLED, BTN_ENABLED, BTN_ENABLED, BTN_ENABLED },
     //
     // PAUSE_EQUIP + PAGE_SWITCH_PT_RIGHT
     //  -> PAUSE_ITEM
@@ -1093,6 +1093,7 @@ void KaleidoScope_SetupPageSwitch(PauseContext* pauseCtx, u8 pt) {
     gSaveContext.buttonStatus[2] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + pt][2];
     gSaveContext.buttonStatus[3] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + pt][3];
     gSaveContext.buttonStatus[4] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + pt][4];
+    dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + pt][1];
 
     PRINTF("kscope->kscp_pos+pt = %d\n", pauseCtx->pageIndex + pt);
 

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -4697,10 +4697,17 @@ void KaleidoScope_Update(PlayState* play) {
             gSaveContext.buttonStatus[2] = D_808321A8[2];
             gSaveContext.buttonStatus[3] = D_808321A8[3];
             gSaveContext.buttonStatus[4] = D_808321A8[4];
-            dpadStatus[0] = D_808321A8[5];
-            dpadStatus[1] = D_808321A8[6];
-            dpadStatus[2] = D_808321A8[7];
-            dpadStatus[3] = D_808321A8[8];
+            
+            if (!switchedDualSet) {
+                dpadStatus[0] = D_808321A8[5];
+                dpadStatus[1] = D_808321A8[6];
+                dpadStatus[2] = D_808321A8[7];
+                dpadStatus[3] = D_808321A8[8];
+            }
+            else {
+                dpadStatus[0] = dpadStatus[1] = dpadStatus[2] = dpadStatus[3] = BTN_ENABLED;
+                switchedDualSet = false;
+            }
             
             interfaceCtx->unk_1FA = interfaceCtx->unk_1FC = 0;
             PRINTF_COLOR_YELLOW();


### PR DESCRIPTION
- Adds D-Pad support
- Throw, aim and use items with D-Pad
- Set items and equipment in Pause Screen with D-Pad
- Set equipment in Pause Screen with C buttons
- Equipped mask and Lens of Truth won't deactivate if it's still on the D-Pad
- No structure changes
- Keep C button alpha enabled in equipment subscreen
- D-Pad alpha in pause screen where viable
- Reused 16 unused bytes in SRAM for storing D-Pad items
- D-Pad Dual Set with L  + R
- Minimap selection upon releasing L without pressing R and within 3 seconds
- Keep mask upon loading scene (tracked for both ages) by using one unused byte in SRAM
- Reset D-Pad layout on loading save file if it has duplicate values in a set (used for existing save files)