### PR TITLE
Increase GameState_Realloc size

### DIFF
--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -307,7 +307,7 @@ void Play_Init(GameState* thisx) {
     SystemArena_Display();
 #endif
 
-    GameState_Realloc(&this->state, 0x1D4790);
+    GameState_Realloc(&this->state, 0x1D4790 + 0x300000);
 
 #if PLATFORM_N64
     if ((B_80121220 != NULL) && (B_80121220->unk_10 != NULL)) {


### PR DESCRIPTION
Fixes out of memory issues in scenes such as Hyrule Field