### PR TITLE
Fontbuf latin fix

### DIFF
--- a/assets/textures/nes_font_static/nes_font_static_all.h
+++ b/assets/textures/nes_font_static/nes_font_static_all.h
@@ -140,5 +140,4 @@ extern u64 gMsgCharA7ButtonCLeftTex[];
 extern u64 gMsgCharA8ButtonCRightTex[];
 extern u64 gMsgCharA9ZTargetSignTex[];
 extern u64 gMsgCharAAControlStickTex[];
-extern u64 gMsgCharACLatinCapitalLetterIWithCircumflexTex[];
 #endif

--- a/src/code/z_kanfont.c
+++ b/src/code/z_kanfont.c
@@ -14,6 +14,9 @@
  */
 void Font_LoadCharWide(Font* font, u16 character, u16 codePointIndex) {
 #if OOT_NTSC
+    if (gSaveContext.language != LANGUAGE_JPN)
+        return;
+
     DMA_REQUEST_SYNC(&font->fontBuf[codePointIndex],
                      (uintptr_t)_kanjiSegmentRomStart + Kanji_OffsetFromShiftJIS(character), FONT_CHAR_TEX_SIZE,
                      "../z_kanfont.c", UNK_LINE);


### PR DESCRIPTION
Fix the latin fontbuf (missing half of the uppercase letters in textboxes, and anything before in the ASCII table) by not overriding the fontbuf with the Japanese wide characters if not in Japanese language mode.