### PR TITLE
Kakariko Gate Guard Exchange Item Fix

### DIFF
--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -432,7 +432,7 @@ void func_80A53AD4(EnHeishi2* this, PlayState* play) {
     yawDiff = ABS(yawDiffTemp);
 
     if (!(120.0f < this->actor.xzDistToPlayer) && (yawDiff < 0x4300)) {
-        Actor_OfferTalkExchangeEquiCylinder(&this->actor, play, 100.0f, EXCH_ITEM_ZELDAS_LETTER);
+        Actor_OfferTalkExchangeEquiCylinder(&this->actor, play, 100.0f, EXCH_ITEM_BOTTLE_BLUE_FIRE);
     }
 }
 


### PR DESCRIPTION
Restores the dialogue when showing the Kakariko Gate Guard a different item than Zelda's Letter.

![gate_guard](https://github.com/user-attachments/assets/8e521acb-9122-4a2e-b908-7dad21d41717)
