### PR TITLE
Fix removed object crashes

### DIFF
--- a/assets/objects/object_oA10/object_oA10.c
+++ b/assets/objects/object_oA10/object_oA10.c
@@ -1,5 +1,0 @@
-#include "ultra64.h"
-#include "z64.h"
-#include "object_oA10.h"
-#include "assets/misc/link_animetion/link_animetion.h"
-#include "assets/objects/gameplay_keep/gameplay_keep.h"

--- a/assets/objects/object_oA10/object_oA10.h
+++ b/assets/objects/object_oA10/object_oA10.h
@@ -1,4 +1,0 @@
-#ifndef OBJECT_OA10_H
-#define OBJECT_OA10_H 1
-
-#endif

--- a/assets/objects/object_oA2/object_oA2.c
+++ b/assets/objects/object_oA2/object_oA2.c
@@ -1,5 +1,0 @@
-#include "ultra64.h"
-#include "z64.h"
-#include "object_oA2.h"
-#include "assets/misc/link_animetion/link_animetion.h"
-#include "assets/objects/gameplay_keep/gameplay_keep.h"

--- a/assets/objects/object_oA2/object_oA2.h
+++ b/assets/objects/object_oA2/object_oA2.h
@@ -1,4 +1,0 @@
-#ifndef OBJECT_OA2_H
-#define OBJECT_OA2_H 1
-
-#endif

--- a/assets/objects/object_oE3/object_oE3.c
+++ b/assets/objects/object_oE3/object_oE3.c
@@ -1,5 +1,0 @@
-#include "ultra64.h"
-#include "z64.h"
-#include "object_oE3.h"
-#include "assets/misc/link_animetion/link_animetion.h"
-#include "assets/objects/gameplay_keep/gameplay_keep.h"

--- a/assets/objects/object_oE3/object_oE3.h
+++ b/assets/objects/object_oE3/object_oE3.h
@@ -1,4 +1,0 @@
-#ifndef OBJECT_OE3_H
-#define OBJECT_OE3_H 1
-
-#endif


### PR DESCRIPTION
Removed the removed objects from #30 (which resulted in empty loaded objects with no data in them). OoT can't handle that and crashes with empty loaded objects.