### PR TITLE
Improve debug translation

### DIFF
--- a/include/translation.h
+++ b/include/translation.h
@@ -11,6 +11,6 @@
  * Note: This translation macro exists for quality of life purposes.
  *       The original game would not have had a macro like this.
  */
-#define T(jp, en) jp
+#define T(jp, en) en
 
 #endif

--- a/src/overlays/gamestates/ovl_select/z_select.c
+++ b/src/overlays/gamestates/ovl_select/z_select.c
@@ -99,193 +99,190 @@ static MapSelectEntry sMapSelectEntries[] = {
     { "17:Death Mountain Crater", MapSelect_LoadGame, ENTR_DEATH_MOUNTAIN_CRATER_0 },
     { "18:Goron City", MapSelect_LoadGame, ENTR_GORON_CITY_0 },
     { "19:Lon Lon Ranch", MapSelect_LoadGame, ENTR_LON_LON_RANCH_0 },
-    { "20:Temple of Time", MapSelect_LoadGame, ENTR_TEMPLE_OF_TIME_0 },
-    { "21:Chamber of Sages", MapSelect_LoadGame, ENTR_CHAMBER_OF_THE_SAGES_0 },
-    { "22:Shooting Gallery", MapSelect_LoadGame, ENTR_SHOOTING_GALLERY_0 },
-    { "23:Castle Courtyard", MapSelect_LoadGame,
+    { "20:" T(GFXP_HIRAGANA "ﾄｷﾉﾏ", "Temple of Time"), MapSelect_LoadGame, ENTR_TEMPLE_OF_TIME_0 },
+    { "21:" T(GFXP_HIRAGANA "ｹﾝｼﾞｬﾉﾏ", "Chamber of Sages"), MapSelect_LoadGame, ENTR_CHAMBER_OF_THE_SAGES_0 },
+    { "22:" T(GFXP_HIRAGANA "ｼｬﾃｷｼﾞｮｳ", "Shooting Gallery"), MapSelect_LoadGame, ENTR_SHOOTING_GALLERY_0 },
+    { "23:" T(GFXP_KATAKANA "ﾊｲﾗﾙ" GFXP_HIRAGANA "ﾆﾜ" GFXP_KATAKANA "ｹﾞｰﾑ", "Castle Courtyard"), MapSelect_LoadGame,
       ENTR_CASTLE_COURTYARD_GUARDS_DAY_0 },
-    { "24:Grave (ReDead)", MapSelect_LoadGame, ENTR_REDEAD_GRAVE_0 },
-    { "25:Grave (Fairy's Fountain)", MapSelect_LoadGame,
+    { "24:" T(GFXP_HIRAGANA "ﾊｶｼﾀﾄﾋﾞｺﾐｱﾅ", "Grave (ReDead)"), MapSelect_LoadGame, ENTR_REDEAD_GRAVE_0 },
+    { "25:" T(GFXP_HIRAGANA "ﾊｶｼﾀﾄﾋﾞｺﾐｱﾅ 2", "Grave (Fairy's Fountain)"), MapSelect_LoadGame,
       ENTR_GRAVE_WITH_FAIRYS_FOUNTAIN_0 },
-    { "26:Royal Family's Tomb", MapSelect_LoadGame, ENTR_ROYAL_FAMILYS_TOMB_0 },
-    { "27:Great Fairy's Fountain (R)", MapSelect_LoadGame,
+    { "26:" T(GFXP_HIRAGANA "ｵｳｹ ﾉ ﾊｶｱﾅ", "Royal Family's Tomb"), MapSelect_LoadGame, ENTR_ROYAL_FAMILYS_TOMB_0 },
+    { "27:" T(GFXP_HIRAGANA "ﾀﾞｲﾖｳｾｲﾉｲｽﾞﾐ", "Great Fairy's Fountain (R)"), MapSelect_LoadGame,
       ENTR_GREAT_FAIRYS_FOUNTAIN_MAGIC_0 },
-    { "28:Fairy's Fountain", MapSelect_LoadGame, ENTR_FAIRYS_FOUNTAIN_0 },
-    { "29:Great Fairy's Fountain (G)", MapSelect_LoadGame,
+    { "28:" T(GFXP_HIRAGANA "ﾄﾋﾞｺﾐ ﾖｳｾｲ ｱﾅ", "Fairy's Fountain"), MapSelect_LoadGame, ENTR_FAIRYS_FOUNTAIN_0 },
+    { "29:" T(GFXP_HIRAGANA "ﾏﾎｳｾｷ ﾖｳｾｲﾉｲｽﾞﾐ", "Great Fairy's Fountain (G)"), MapSelect_LoadGame,
       ENTR_GREAT_FAIRYS_FOUNTAIN_SPELLS_0 },
-    { "30:Top of Ganon's Tower", MapSelect_LoadGame,
+    { "30:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ｻｲｼｭｳｾﾝ", "Top of Ganon's Tower"), MapSelect_LoadGame,
       ENTR_GANONS_TOWER_COLLAPSE_EXTERIOR_0 },
-    { "31:Zelda's Courtyard", MapSelect_LoadGame,
+    { "31:" T(GFXP_KATAKANA "ﾊｲﾗﾙ" GFXP_HIRAGANA "ﾅｶﾆﾜ", "Zelda's Courtyard"), MapSelect_LoadGame,
       ENTR_CASTLE_COURTYARD_ZELDA_0 },
-    { "32:Fishing Pond", MapSelect_LoadGame, ENTR_FISHING_POND_0 },
-    { "33:Bombchu Bowling Alley", MapSelect_LoadGame, ENTR_BOMBCHU_BOWLING_ALLEY_0 },
+    { "32:" T(GFXP_HIRAGANA "ﾂﾘﾎﾞﾘ", "Fishing Pond"), MapSelect_LoadGame, ENTR_FISHING_POND_0 },
+    { "33:" T(GFXP_KATAKANA "ﾎﾞﾑﾁｭｳﾎﾞｰﾘﾝｸﾞ", "Bombchu Bowling Alley"), MapSelect_LoadGame, ENTR_BOMBCHU_BOWLING_ALLEY_0 },
     // Talon's House
-    { "34:Talon's House", MapSelect_LoadGame,
+    { "34:" T(GFXP_KATAKANA "ﾛﾝﾛﾝ" GFXP_HIRAGANA "ﾎﾞｸｼﾞｮｳ ｿｳｺ 1", "Talon's House"), MapSelect_LoadGame,
       ENTR_LON_LON_BUILDINGS_0 },
     // Ranch Silo
-    { "35:Ranch Silo", MapSelect_LoadGame,
+    { "35:" T(GFXP_KATAKANA "ﾛﾝﾛﾝ" GFXP_HIRAGANA "ﾎﾞｸｼﾞｮｳ ｿｳｺ 2", "Ranch Silo"), MapSelect_LoadGame,
       ENTR_LON_LON_BUILDINGS_1 },
-    { "36:Guard House", MapSelect_LoadGame, ENTR_MARKET_GUARD_HOUSE_0 },
-    { "37:Granny's Potion Shop", MapSelect_LoadGame, ENTR_POTION_SHOP_GRANNY_0 },
-    { "38:Treasure Box Shop", MapSelect_LoadGame, ENTR_TREASURE_BOX_SHOP_0 },
-    { "39:House of Skulltula", MapSelect_LoadGame,
+    { "36:" T(GFXP_HIRAGANA "ﾐﾊﾘ ｺﾞﾔ", "Guard House"), MapSelect_LoadGame, ENTR_MARKET_GUARD_HOUSE_0 },
+    { "37:" T(GFXP_HIRAGANA "ﾏﾎｳ ﾉ ｸｽﾘﾔ", "Granny's Potion Shop"), MapSelect_LoadGame, ENTR_POTION_SHOP_GRANNY_0 },
+    { "38:" T(GFXP_HIRAGANA "ﾀｶﾗﾊﾞｺﾔ", "Treasure Box Shop"), MapSelect_LoadGame, ENTR_TREASURE_BOX_SHOP_0 },
+    { "39:" T(GFXP_HIRAGANA "ｷﾝ " GFXP_KATAKANA "ｽﾀﾙﾁｭﾗ ﾊｳｽ", "House of Skulltula"), MapSelect_LoadGame,
       ENTR_HOUSE_OF_SKULLTULA_0 },
-    { "40:Market Entrance", MapSelect_LoadGame,
+    { "40:" T(GFXP_HIRAGANA "ｼﾞｮｳｶﾏﾁ ｲﾘｸﾞﾁ", "Market Entrance"), MapSelect_LoadGame,
       ENTR_MARKET_ENTRANCE_DAY_0 },
-    { "41:Market", MapSelect_LoadGame, ENTR_MARKET_DAY_0 },
-    { "42:Market Back Alley", MapSelect_LoadGame, ENTR_BACK_ALLEY_DAY_0 },
-    { "43:Temple of Time (Exterior)", MapSelect_LoadGame,
+    { "41:" T(GFXP_HIRAGANA "ｼﾞｮｳｶﾏﾁ", "Market"), MapSelect_LoadGame, ENTR_MARKET_DAY_0 },
+    { "42:" T(GFXP_HIRAGANA "ｳﾗﾛｼﾞ", "Back Alley"), MapSelect_LoadGame, ENTR_BACK_ALLEY_DAY_0 },
+    { "43:" T(GFXP_HIRAGANA "ﾄｷﾉｼﾝﾃﾞﾝ ﾏｴ", "Temple of Time (Exterior)"), MapSelect_LoadGame,
       ENTR_TEMPLE_OF_TIME_EXTERIOR_DAY_0 },
-    { "44:Link's House", MapSelect_LoadGame, ENTR_LINKS_HOUSE_0 },
-    { "45:Kakariko Guest House", MapSelect_LoadGame,
+    { "44:" T(GFXP_HIRAGANA "ﾘﾝｸﾉｲｴ", "Link's House"), MapSelect_LoadGame, ENTR_LINKS_HOUSE_0 },
+    { "45:" T(GFXP_KATAKANA "ｶｶﾘｺ" GFXP_HIRAGANA "ﾑﾗﾉﾅｶﾞﾔ", "Kakariko Guest House"), MapSelect_LoadGame,
       ENTR_KAKARIKO_CENTER_GUEST_HOUSE_0 },
-    { "46:Market Back Alley House", MapSelect_LoadGame, ENTR_BACK_ALLEY_HOUSE_0 },
-    { "47:Know-It-All Brothers' House", MapSelect_LoadGame,
+    { "46:" T(GFXP_HIRAGANA "ｳﾗﾛｼﾞﾉ ｲｴ", "Back Alley House"), MapSelect_LoadGame, ENTR_BACK_ALLEY_HOUSE_0 },
+    { "47:" T(GFXP_HIRAGANA "ｺｷﾘﾉﾑﾗ ﾓﾉｼﾘｷｮｳﾀﾞｲﾉｲｴ", "Know-It-All Brothers' House"), MapSelect_LoadGame,
       ENTR_KNOW_IT_ALL_BROS_HOUSE_0 },
-    { "48:Twins' House", MapSelect_LoadGame,
+    { "48:" T(GFXP_HIRAGANA "ｺｷﾘﾉﾑﾗ ﾌﾀｺﾞﾉｲｴ", "Twins' House"), MapSelect_LoadGame,
       ENTR_TWINS_HOUSE_0 },
-    { "49:Mido's House",
+    { "49:" T(GFXP_HIRAGANA "ｺｷﾘﾉﾑﾗ " GFXP_KATAKANA "ﾐﾄﾞ" GFXP_HIRAGANA "ﾉｲｴ", "Mido's House"),
       MapSelect_LoadGame, ENTR_MIDOS_HOUSE_0 },
-    { "50:Saria's House",
+    { "50:" T(GFXP_HIRAGANA "ｺｷﾘﾉﾑﾗ " GFXP_KATAKANA "ｻﾘｱ" GFXP_HIRAGANA "ﾉｲｴ", "Saria's House"),
       MapSelect_LoadGame, ENTR_SARIAS_HOUSE_0 },
-    { "51:Stable", MapSelect_LoadGame, ENTR_STABLE_0 },
-    { "52:Gravekeeper's Hut", MapSelect_LoadGame, ENTR_GRAVEKEEPERS_HUT_0 },
-    { "53:Dog Lady's House", MapSelect_LoadGame,
+    { "51:" T(GFXP_HIRAGANA "ｳﾏｺﾞﾔ", "Stable"), MapSelect_LoadGame, ENTR_STABLE_0 },
+    { "52:" T(GFXP_HIRAGANA "ﾊｶﾓﾘﾉｲｴ", "Gravekeeper's Hut"), MapSelect_LoadGame, ENTR_GRAVEKEEPERS_HUT_0 },
+    { "53:" T(GFXP_HIRAGANA "ｳﾗﾛｼﾞ ｲﾇｵﾊﾞｻﾝﾉｲｴ", "Dog Lady's House"), MapSelect_LoadGame,
       ENTR_DOG_LADY_HOUSE_0 },
-    { "54:Impa's House",
+    { "54:" T(GFXP_HIRAGANA "ｶｶﾘｺﾑﾗ " GFXP_KATAKANA "ｲﾝﾊﾟ" GFXP_HIRAGANA "ﾉｲｴ", "Impa's House"),
       MapSelect_LoadGame, ENTR_IMPAS_HOUSE_0 },
-    { "55:Lakeside Laboratory", MapSelect_LoadGame,
+    { "55:" T(GFXP_KATAKANA "ﾊｲﾘｱ" GFXP_HIRAGANA " ｹﾝｷｭｳｼﾞｮ", "Lakeside Laboratory"), MapSelect_LoadGame,
       ENTR_LAKESIDE_LABORATORY_0 },
-    { "56:Tent", MapSelect_LoadGame, ENTR_CARPENTERS_TENT_0 },
-    { "57:Bazaar", MapSelect_LoadGame, ENTR_BAZAAR_0 },
-    { "58:Kokiri Shop", MapSelect_LoadGame, ENTR_KOKIRI_SHOP_0 },
-    { "59:Goron Shop", MapSelect_LoadGame, ENTR_GORON_SHOP_0 },
-    { "60:Zora Shop", MapSelect_LoadGame, ENTR_ZORA_SHOP_0 },
-    { "61:Potion Shop (Kakariko)", MapSelect_LoadGame,
+    { "56:" T(GFXP_KATAKANA "ﾃﾝﾄ", "Tent"), MapSelect_LoadGame, ENTR_CARPENTERS_TENT_0 },
+    { "57:" T(GFXP_HIRAGANA "ﾀﾃﾉﾐｾ", "Bazaar"), MapSelect_LoadGame, ENTR_BAZAAR_0 },
+    { "58:" T(GFXP_HIRAGANA "ｺｷﾘｿﾞｸﾉﾐｾ", "Kokiri Shop"), MapSelect_LoadGame, ENTR_KOKIRI_SHOP_0 },
+    { "59:" T(GFXP_KATAKANA "ｺﾞﾛﾝ" GFXP_HIRAGANA "ﾉﾐｾ", "Goron Shop"), MapSelect_LoadGame, ENTR_GORON_SHOP_0 },
+    { "60:" T(GFXP_KATAKANA "ｿﾞｰﾗ" GFXP_HIRAGANA "ﾉﾐｾ", "Zora Shop"), MapSelect_LoadGame, ENTR_ZORA_SHOP_0 },
+    { "61:" T(GFXP_KATAKANA "ｶｶﾘｺ" GFXP_HIRAGANA "ﾑﾗ  ｸｽﾘﾔ", "Potion Shop (Kakariko)"), MapSelect_LoadGame,
       ENTR_POTION_SHOP_KAKARIKO_0 },
-    { "62:Potion Shop (Market)", MapSelect_LoadGame,
+    { "62:" T(GFXP_HIRAGANA "ｼﾞｮｳｶﾏﾁ ｸｽﾘﾔ", "Potion Shop (Market)"), MapSelect_LoadGame,
       ENTR_POTION_SHOP_MARKET_0 },
-    { "63:Bombchu Shop", MapSelect_LoadGame, ENTR_BOMBCHU_SHOP_0 },
-    { "64:Happy Mask Shop", MapSelect_LoadGame, ENTR_HAPPY_MASK_SHOP_0 },
-    { "65:Gerudo Training Ground", MapSelect_LoadGame,
+    { "63:" T(GFXP_HIRAGANA "ｳﾗﾛｼﾞ ﾖﾙﾉﾐｾ", "Bombchu Shop"), MapSelect_LoadGame, ENTR_BOMBCHU_SHOP_0 },
+    { "64:" T(GFXP_HIRAGANA "ｵﾒﾝﾔ", "Happy Mask Shop"), MapSelect_LoadGame, ENTR_HAPPY_MASK_SHOP_0 },
+    { "65:" T(GFXP_KATAKANA "ｹﾞﾙﾄﾞ" GFXP_HIRAGANA "ﾉｼｭｳﾚﾝｼﾞｮｳ", "Gerudo Training Ground"), MapSelect_LoadGame,
       ENTR_GERUDO_TRAINING_GROUND_0 },
-    { "66:Deku Tree", MapSelect_LoadGame,
+    { "66:" T(GFXP_HIRAGANA "ﾖｳｾｲﾉｷﾉ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ", "Deku Tree"), MapSelect_LoadGame,
       ENTR_DEKU_TREE_0 },
-    { "67:Deku Tree (Boss)", MapSelect_LoadGame,
+    { "67:" T(GFXP_HIRAGANA "ﾖｳｾｲﾉｷﾉ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ ﾎﾞｽ", "Deku Tree (Boss)"), MapSelect_LoadGame,
       ENTR_DEKU_TREE_BOSS_0 },
-    { "68:Dodongo's Cavern", MapSelect_LoadGame, ENTR_DODONGOS_CAVERN_0 },
-    { "69:Dodongo's Cavern (Boss)", MapSelect_LoadGame,
+    { "68:" T(GFXP_KATAKANA "ﾄﾞﾄﾞﾝｺﾞ ﾀﾞﾝｼﾞｮﾝ", "Dodongo's Cavern"), MapSelect_LoadGame, ENTR_DODONGOS_CAVERN_0 },
+    { "69:" T(GFXP_KATAKANA "ﾄﾞﾄﾞﾝｺﾞ ﾀﾞﾝｼﾞｮﾝ ﾎﾞｽ", "Dodongo's Cavern (Boss)"), MapSelect_LoadGame,
       ENTR_DODONGOS_CAVERN_BOSS_0 },
-    { "70:Jabu-Jabu", MapSelect_LoadGame,
+    { "70:" T(GFXP_HIRAGANA "ｷｮﾀﾞｲｷﾞｮ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ", "Jabu-Jabu"), MapSelect_LoadGame,
       ENTR_JABU_JABU_0 },
-    { "71:Jabu-Jabu (Boss)", MapSelect_LoadGame,
+    { "71:" T(GFXP_HIRAGANA "ｷｮﾀﾞｲｷﾞｮ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ ﾎﾞｽ", "Jabu-Jabu (Boss)"), MapSelect_LoadGame,
       ENTR_JABU_JABU_BOSS_0 },
-    { "72:Forest Temple", MapSelect_LoadGame, ENTR_FOREST_TEMPLE_0 },
-    { "73:Forest Temple (Boss)", MapSelect_LoadGame,
+    { "72:" T(GFXP_HIRAGANA "ﾓﾘﾉｼﾝﾃﾞﾝ", "Forest Temple"), MapSelect_LoadGame, ENTR_FOREST_TEMPLE_0 },
+    { "73:" T(GFXP_HIRAGANA "ﾓﾘﾉｼﾝﾃﾞﾝ " GFXP_KATAKANA "ﾎﾞｽ", "Forest Temple (Boss)"), MapSelect_LoadGame,
       ENTR_FOREST_TEMPLE_BOSS_0 },
-    { "74:Bottom of the Well", MapSelect_LoadGame,
+    { "74:" T(GFXP_HIRAGANA "ｲﾄﾞｼﾀ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ", "Bottom of the Well"), MapSelect_LoadGame,
       ENTR_BOTTOM_OF_THE_WELL_0 },
-    { "75:Shadow Temple", MapSelect_LoadGame,
+    { "75:" T(GFXP_HIRAGANA "ﾊｶｼﾀ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ", "Shadow Temple"), MapSelect_LoadGame,
       ENTR_SHADOW_TEMPLE_0 },
-    { "76:Shadow Temple (Boss)",
+    { "76:" T(GFXP_HIRAGANA "ﾊｶｼﾀ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ ﾎﾞｽ", "Shadow Temple (Boss)"),
       MapSelect_LoadGame, ENTR_SHADOW_TEMPLE_BOSS_0 },
-    { "77:Fire Temple", MapSelect_LoadGame, ENTR_FIRE_TEMPLE_0 },
-    { "78:Fire Temple (Boss)", MapSelect_LoadGame,
+    { "77:" T(GFXP_HIRAGANA "ﾋﾉｼﾝﾃﾞﾝ", "Fire Temple"), MapSelect_LoadGame, ENTR_FIRE_TEMPLE_0 },
+    { "78:" T(GFXP_HIRAGANA "ﾋﾉｼﾝﾃﾞﾝ " GFXP_KATAKANA "ﾎﾞｽ", "Fire Temple (Boss)"), MapSelect_LoadGame,
       ENTR_FIRE_TEMPLE_BOSS_0 },
-    { "79:Water Temple", MapSelect_LoadGame, ENTR_WATER_TEMPLE_0 },
-    { "80:Water Temple (Boss)", MapSelect_LoadGame,
+    { "79:" T(GFXP_HIRAGANA "ﾐｽﾞﾉｼﾝﾃﾞﾝ", "Water Temple"), MapSelect_LoadGame, ENTR_WATER_TEMPLE_0 },
+    { "80:" T(GFXP_HIRAGANA "ﾐｽﾞﾉｼﾝﾃﾞﾝ " GFXP_KATAKANA "ﾎﾞｽ", "Water Temple (Boss)"), MapSelect_LoadGame,
       ENTR_WATER_TEMPLE_BOSS_0 },
-    { "81:Spirit Temple", MapSelect_LoadGame,
+    { "81:" T(GFXP_HIRAGANA "ｼﾞｬｼﾝｿﾞｳ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ", "Spirit Temple"), MapSelect_LoadGame,
       ENTR_SPIRIT_TEMPLE_0 },
     // Iron Knuckle's Lair
-    { "82:Spirit Temple (Iron Knuckle)",
+    { "82:" T(GFXP_HIRAGANA "ｼﾞｬｼﾝｿﾞｳ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ ｱｲｱﾝﾅｯｸ", "Spirit Temple (Iron Knuckle)"),
       MapSelect_LoadGame, ENTR_SPIRIT_TEMPLE_BOSS_0 },
     // Twinrova's Lair
-    { "83:Spirit Temple (Boss)",
+    { "83:" T(GFXP_HIRAGANA "ｼﾞｬｼﾝｿﾞｳ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ ﾎﾞｽ", "Spirit Temple (Boss)"),
       MapSelect_LoadGame, ENTR_SPIRIT_TEMPLE_BOSS_2 },
-    { "84:Ganon's Tower", MapSelect_LoadGame, ENTR_GANONS_TOWER_0 },
-    { "85:Ganondorf (Boss)", MapSelect_LoadGame,
+    { "84:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾉﾄｳ", "Ganon's Tower"), MapSelect_LoadGame, ENTR_GANONS_TOWER_0 },
+    { "85:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾉﾄｳ" GFXP_KATAKANA "ﾎﾞｽ", "Ganon's Tower (Boss)"), MapSelect_LoadGame,
       ENTR_GANONDORF_BOSS_0 },
-    { "86:Ice Cavern", MapSelect_LoadGame, ENTR_ICE_CAVERN_0 },
+    { "86:" T(GFXP_HIRAGANA "ｺｵﾘﾉﾄﾞｳｸﾂ", "Ice Cavern"), MapSelect_LoadGame, ENTR_ICE_CAVERN_0 },
     // Dampé's Grave
-    { "87:Dampe's Grave", MapSelect_LoadGame,
+    { "87:" T(GFXP_HIRAGANA "ﾊｶｼﾀ" GFXP_KATAKANA "ﾘﾚｰ", "Dampe's Grave"), MapSelect_LoadGame,
       ENTR_WINDMILL_AND_DAMPES_GRAVE_0 },
-    { "88:Inside Ganon's Castle",
+    { "88:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾁｶ " GFXP_KATAKANA "ﾀﾞﾝｼﾞｮﾝ", "Inside Ganon's Castle"),
       MapSelect_LoadGame, ENTR_INSIDE_GANONS_CASTLE_0 },
-    { "89:Ganon (Boss)",
+    { "89:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ｻｲｼｭｳｾﾝ " GFXP_KATAKANA "ﾃﾞﾓ & ﾊﾞﾄﾙ",
+              "Ganon (Boss)"),
       MapSelect_LoadGame, ENTR_GANON_BOSS_0 },
-    { "90:Ganon's Tower Collapse 1", MapSelect_LoadGame,
+    { "90:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾉﾄｳ ｿﾉｺﾞ 1", "Ganon's Tower Collapse 1"), MapSelect_LoadGame,
       ENTR_GANONS_TOWER_COLLAPSE_INTERIOR_0 },
-    { "91:Ganon's Tower Collapse 2", MapSelect_LoadGame,
+    { "91:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾉﾄｳ ｿﾉｺﾞ 2", "Ganon's Tower Collapse 2"), MapSelect_LoadGame,
       ENTR_GANONS_TOWER_COLLAPSE_INTERIOR_2 },
-    { "92:Ganon's Tower Collapse 3", MapSelect_LoadGame,
+    { "92:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾉﾄｳ ｿﾉｺﾞ 3", "Ganon's Tower Collapse 3"), MapSelect_LoadGame,
       ENTR_GANONS_TOWER_COLLAPSE_INTERIOR_4 },
-    { "93:Ganon's Tower Collapse 4", MapSelect_LoadGame,
+    { "93:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾉﾄｳ ｿﾉｺﾞ 4", "Ganon's Tower Collapse 4"), MapSelect_LoadGame,
       ENTR_GANONS_TOWER_COLLAPSE_INTERIOR_6 },
-    { "94:Ganon's Tower Collapse 5", MapSelect_LoadGame,
+    { "94:" T(GFXP_KATAKANA "ｶﾞﾉﾝ" GFXP_HIRAGANA "ﾁｶ ｿﾉｺﾞ", "Ganon's Tower Collapse 5"), MapSelect_LoadGame,
       ENTR_INSIDE_GANONS_CASTLE_COLLAPSE_0 },
-    { "95:Thieves' Hideout 1", MapSelect_LoadGame,
+    { "95:" T(GFXP_KATAKANA "ｹﾞﾙﾄﾞ" GFXP_HIRAGANA "ﾂｳﾛ 1-2", "Thieves' Hideout 1-2"), MapSelect_LoadGame,
       ENTR_THIEVES_HIDEOUT_0 },
-    { "96:Thieves' Hideout 2", MapSelect_LoadGame,
+    { "96:" T(GFXP_KATAKANA "ｹﾞﾙﾄﾞ" GFXP_HIRAGANA "ﾂｳﾛ 3-4 9-10", "Thieves' Hideout 3-4 9-10"), MapSelect_LoadGame,
       ENTR_THIEVES_HIDEOUT_2 },
-    { "97:Thieves' Hideout 3", MapSelect_LoadGame,
+    { "97:" T(GFXP_KATAKANA "ｹﾞﾙﾄﾞ" GFXP_HIRAGANA "ﾂｳﾛ 5-6", "Thieves' Hideout 5-6"), MapSelect_LoadGame,
       ENTR_THIEVES_HIDEOUT_4 },
-    { "98:Thieves' Hideout 4", MapSelect_LoadGame,
+    { "98:" T(GFXP_KATAKANA "ｹﾞﾙﾄﾞ" GFXP_HIRAGANA "ﾂｳﾛ 7-8", "Thieves' Hideout 7-8"), MapSelect_LoadGame,
       ENTR_THIEVES_HIDEOUT_6 },
-    { "99:Thieves' Hideout 5", MapSelect_LoadGame,
+    { "99:" T(GFXP_KATAKANA "ｹﾞﾙﾄﾞ" GFXP_HIRAGANA "ﾂｳﾛ 11-12", "Thieves' Hideout 11-12"), MapSelect_LoadGame,
       ENTR_THIEVES_HIDEOUT_10 },
-    { "100:Thieves' Hideout 6", MapSelect_LoadGame,
+    { "100:" T(GFXP_KATAKANA "ｹﾞﾙﾄﾞ" GFXP_HIRAGANA "ﾂｳﾛ 13", "Thieves' Hideout 13"), MapSelect_LoadGame,
       ENTR_THIEVES_HIDEOUT_12 },
     // Gossip Stone & Chest Grotto
-    { "101:Grotto (Gossip Stone)", MapSelect_LoadGame, ENTR_GROTTOS_0 },
+    { "101:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 0", "Grotto (Gossip Stone)"), MapSelect_LoadGame, ENTR_GROTTOS_0 },
     // Skulltula & Gold Skulltula Grotto
-    { "102:Grotto (Skulltula)", MapSelect_LoadGame, ENTR_GROTTOS_1 },
+    { "102:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 1", "Grotto (Skulltula)"), MapSelect_LoadGame, ENTR_GROTTOS_1 },
     // Business Scrub & Heart Piece Grotto
-    { "103:Grotto (Business Scrub)", MapSelect_LoadGame, ENTR_GROTTOS_2 },
+    { "103:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 2", "Grotto (Business Scrub)"), MapSelect_LoadGame, ENTR_GROTTOS_2 },
     // Redeads Grotto
-    { "104:Grotto (ReDeads)", MapSelect_LoadGame, ENTR_GROTTOS_3 },
+    { "104:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 3", "Grotto (ReDeads)"), MapSelect_LoadGame, ENTR_GROTTOS_3 },
     // 3 Business Scrubs Grotto
-    { "105:Grotto (3 Business Scrubs)", MapSelect_LoadGame, ENTR_GROTTOS_4 },
+    { "105:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 4", "Grotto (3 Business Scrubs)"), MapSelect_LoadGame, ENTR_GROTTOS_4 },
     // Gossip Stone, Skulltula & Cow Grotto
-    { "106:Grotto (GS & Cow)", MapSelect_LoadGame, ENTR_GROTTOS_5 },
+    { "106:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 5", "Grotto (GS & Cow)"), MapSelect_LoadGame, ENTR_GROTTOS_5 },
     // Octorok Grotto
-    { "107:Grotto (Octorok)", MapSelect_LoadGame, ENTR_GROTTOS_6 },
+    { "107:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 6", "Grotto (Octorok)"), MapSelect_LoadGame, ENTR_GROTTOS_6 },
     // Business Scrub & Deku Nut Upgrade Grotto
-    { "108:Grotto (Deku Nut Upgrade)", MapSelect_LoadGame, ENTR_GROTTOS_7 },
+    { "108:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 7", "Grotto (Deku Nut Upgrade)"), MapSelect_LoadGame, ENTR_GROTTOS_7 },
     // 2 Wolfos Grotto
-    { "109:Grotto (Wolfos)", MapSelect_LoadGame, ENTR_GROTTOS_8 },
+    { "109:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 8", "Grotto (Wolfos)"), MapSelect_LoadGame, ENTR_GROTTOS_8 },
     // Bombable Walls Grotto
-    { "110:Grotto (Bombable Walls)", MapSelect_LoadGame, ENTR_GROTTOS_9 },
+    { "110:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 9", "Grotto (Bombable Walls)"), MapSelect_LoadGame, ENTR_GROTTOS_9 },
     // 2 Business Scrubs Grotto
-    { "111:Grotto (2 Business Scrubs)", MapSelect_LoadGame, ENTR_GROTTOS_10 },
+    { "111:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 10", "Grotto (2 Business Scrubs)"), MapSelect_LoadGame, ENTR_GROTTOS_10 },
     // Tektite & Heart Piece Grotto
-    { "112:Grotto (Tektite)", MapSelect_LoadGame, ENTR_GROTTOS_11 },
+    { "112:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 11", "Grotto (Tektite)"), MapSelect_LoadGame, ENTR_GROTTOS_11 },
     // Deku Stage Grotto
-    { "113:Grotto (Deku Stage)", MapSelect_LoadGame, ENTR_GROTTOS_12 },
+    { "113:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 12", "Grotto (Deku Stage)"), MapSelect_LoadGame, ENTR_GROTTOS_12 },
     // Rupees & Cow Grotto
-    { "114:Grotto (Rupees & Cow)", MapSelect_LoadGame, ENTR_GROTTOS_13 },
-    { "115:Cutscene Map", MapSelect_LoadGame, ENTR_CUTSCENE_MAP_0 },
-#if DEBUG_FEATURES
-    { "116:Besitu",
+    { "114:" T(GFXP_HIRAGANA "ｶｸｼﾄﾋﾞｺﾐｱﾅ 13", "Grotto (Rupees & Cow)"), MapSelect_LoadGame, ENTR_GROTTOS_13 },
+    { "115:" T(GFXP_KATAKANA "ﾊｲﾗﾙ ﾃﾞﾓ", "Cutscene Map"), MapSelect_LoadGame, ENTR_CUTSCENE_MAP_0 },
+#if DEBUG_ASSETS
+    { "116:" T(GFXP_HIRAGANA "ﾍﾞｯｼﾂ (ﾀｶﾗﾊﾞｺ" GFXP_KATAKANA "ﾜｰﾌﾟ)", "Besitu"),
       MapSelect_LoadGame, ENTR_BESITU_0 },
-    { "117:Sasa Test", MapSelect_LoadGame, ENTR_SASATEST_0 },
-    { "118:Test", MapSelect_LoadGame, ENTR_TEST01_0 },
-    { "119:Test Room", MapSelect_LoadGame, ENTR_TESTROOM_0 },
-    { "120:Syotes",
+    { "117:" T(GFXP_HIRAGANA "ｻｻ" GFXP_KATAKANA "ﾃｽﾄ", "Sasa Test"), MapSelect_LoadGame, ENTR_SASATEST_0 },
+    { "118:" T(GFXP_KATAKANA "ﾃｽﾄﾏｯﾌﾟ", "Test"), MapSelect_LoadGame, ENTR_TEST01_0 },
+    { "119:" T(GFXP_KATAKANA "ﾃｽﾄﾙｰﾑ", "Test Room"), MapSelect_LoadGame, ENTR_TESTROOM_0 },
+    { "120:" T(GFXP_HIRAGANA "ﾁｭｳ" GFXP_KATAKANA "ｽﾀﾛﾌｫｽ" GFXP_HIRAGANA "ﾍﾞﾔ", "Syotes"),
       MapSelect_LoadGame, ENTR_SYOTES_0 },
-    { "121:Syotes 2", MapSelect_LoadGame,
+    { "121:" T(GFXP_KATAKANA "ﾎﾞｽｽﾀﾛﾌｫｽ" GFXP_HIRAGANA "ﾍﾞﾔ", "Syotes 2"), MapSelect_LoadGame,
       ENTR_SYOTES2_0 },
-    { "122:Sutaru", MapSelect_LoadGame, ENTR_SUTARU_0 },
-    { "123:Shooting Gallery (Test)", MapSelect_LoadGame, ENTR_TEST_SHOOTING_GALLERY_0 },
-    { "124:Depth Test", MapSelect_LoadGame, ENTR_DEPTH_TEST_0 },
-    { "125:Castle Courtyard (Beta)",
+    { "122:" "Sutaru", MapSelect_LoadGame, ENTR_SUTARU_0 },
+    { "123:" T("jikkenjyou", "Shooting Gallery (Test)"), MapSelect_LoadGame, ENTR_TEST_SHOOTING_GALLERY_0 },
+    { "124:Depth" T(GFXP_KATAKANA " ﾃｽﾄ", " Test"), MapSelect_LoadGame, ENTR_DEPTH_TEST_0 },
+    { "125:" T(GFXP_KATAKANA "ﾊｲﾗﾙ" GFXP_HIRAGANA "ﾆﾜ" GFXP_KATAKANA "ｹﾞｰﾑ2", "Castle Courtyard (Beta)"),
       MapSelect_LoadGame, ENTR_HAIRAL_NIWA2_0 },
 #endif
     { "Title", (void*)MapSelect_LoadTitle, 0 },
-#if PLATFORM_N64
-    { "64DD TEST  n64dd_SetDiskVersion(1)", (void*)func_80800AD0_unknown, 0 },
-    { "64DD TEST2 n64dd_SetDiskVersion(0)", (void*)func_80800B08_unknown, 0 },
-#endif
 };
 
 void MapSelect_UpdateMenu(MapSelectState* this) {
@@ -529,18 +526,19 @@ void MapSelect_PrintMenu(MapSelectState* this, GfxPrint* printer) {
 }
 
 static const char* sLoadingMessages[] = {
-    "Please wait a minute",
-    "Hold on a sec",
-    "Wait a moment",
-    "Loading",
-    "Now working",
-    "Now creating",
-    "It's not broken",
-    "Coffee Break",
-    "Please set B side",
-    "Be patient, now",
-    "Please wait just a minute",
-    "Don't worry, take a break.",
+    T(GFXP_HIRAGANA "ｼﾊﾞﾗｸｵﾏﾁｸﾀﾞｻｲ", "Please wait a minute"),
+    T(GFXP_HIRAGANA "ﾁｮｯﾄ ﾏｯﾃﾈ", "Hold on a sec"),
+    T(GFXP_KATAKANA "ｳｪｲﾄ ｱ ﾓｰﾒﾝﾄ", "Wait a moment"),
+    T(GFXP_KATAKANA "ﾛｰﾄﾞ" GFXP_HIRAGANA "ﾁｭｳ", "Loading"),
+    T(GFXP_HIRAGANA "ﾅｳ ﾜｰｷﾝｸﾞ", "Now working"),
+    T(GFXP_HIRAGANA "ｲﾏ ﾂｸｯﾃﾏｽ", "Now creating"),
+    T(GFXP_HIRAGANA "ｺｼｮｳｼﾞｬﾅｲﾖ", "It's not broken"),
+    T(GFXP_KATAKANA "ｺｰﾋｰ ﾌﾞﾚｲｸ", "Coffee Break"),
+    T(GFXP_KATAKANA "Bﾒﾝｦｾｯﾄｼﾃｸﾀﾞｻｲ", "Please set B side"),
+    T(GFXP_HIRAGANA "ｼﾞｯﾄ" GFXP_KATAKANA "ｶﾞﾏﾝ" GFXP_HIRAGANA "ﾉ" GFXP_KATAKANA "ｺ" GFXP_HIRAGANA "ﾃﾞｱｯﾀ",
+      "Be patient, now"),
+    T(GFXP_HIRAGANA "ｲﾏｼﾊﾞﾗｸｵﾏﾁｸﾀﾞｻｲ", "Please wait just a minute"),
+    T(GFXP_HIRAGANA "ｱﾜﾃﾅｲｱﾜﾃﾅｲ｡ﾋﾄﾔｽﾐﾋﾄﾔｽﾐ｡", "Don't worry, take a break."),
 };
 
 void MapSelect_PrintLoadingMessage(MapSelectState* this, GfxPrint* printer) {
@@ -553,8 +551,8 @@ void MapSelect_PrintLoadingMessage(MapSelectState* this, GfxPrint* printer) {
 }
 
 static const char* sAgeLabels[] = {
-    "17(Adult)",
-    "10(Child)",
+    T(GFXP_HIRAGANA "17(ﾜｶﾓﾉ)", "17(Adult)"),
+    T(GFXP_HIRAGANA "10(ﾜｶｽｷﾞ)", "10(Child)"),
 };
 
 void MapSelect_PrintAgeSetting(MapSelectState* this, GfxPrint* printer, s32 age) {
@@ -571,48 +569,48 @@ void MapSelect_PrintCutsceneSetting(MapSelectState* this, GfxPrint* printer, u16
 
     switch (csIndex) {
         case 0:
-            label = "Night";
+            label = T(GFXP_HIRAGANA " ﾖﾙ " GFXP_KATAKANA "ｺﾞﾛﾝ", "Night");
             gSaveContext.save.dayTime = CLOCK_TIME(0, 0);
             break;
         case 0x8000:
             // clang-format off
-            gSaveContext.save.dayTime = CLOCK_TIME(12, 0); label = "Day";
+            gSaveContext.save.dayTime = CLOCK_TIME(12, 0); label = T(GFXP_HIRAGANA "ｵﾋﾙ " GFXP_KATAKANA "ｼﾞｬﾗ", "Day");
             // clang-format on
             break;
         case 0xFFF0:
             // clang-format off
-            gSaveContext.save.dayTime = CLOCK_TIME(12, 0); label = "Cutscene 00";
+            gSaveContext.save.dayTime = CLOCK_TIME(12, 0); label = T("ﾃﾞﾓ00", "Cutscene 00");
             // clang-format on
             break;
         case 0xFFF1:
-            label = "Cutscene 01";
+            label = T("ﾃﾞﾓ01", "Cutscene 01");
             break;
         case 0xFFF2:
-            label = "Cutscene 02";
+            label = T("ﾃﾞﾓ02", "Cutscene 02");
             break;
         case 0xFFF3:
-            label = "Cutscene 03";
+            label = T("ﾃﾞﾓ03", "Cutscene 03");
             break;
         case 0xFFF4:
-            label = "Cutscene 04";
+            label = T("ﾃﾞﾓ04", "Cutscene 04");
             break;
         case 0xFFF5:
-            label = "Cutscene 05";
+            label = T("ﾃﾞﾓ05", "Cutscene 05");
             break;
         case 0xFFF6:
-            label = "Cutscene 06";
+            label = T("ﾃﾞﾓ06", "Cutscene 06");
             break;
         case 0xFFF7:
-            label = "Cutscene 07";
+            label = T("ﾃﾞﾓ07", "Cutscene 07");
             break;
         case 0xFFF8:
-            label = "Cutscene 08";
+            label = T("ﾃﾞﾓ08", "Cutscene 08");
             break;
         case 0xFFF9:
-            label = "Cutscene 09";
+            label = T("ﾃﾞﾓ09", "Cutscene 09");
             break;
         case 0xFFFA:
-            label = "Cutscene 0A";
+            label = T("ﾃﾞﾓ0A", "Cutscene 0A");
             break;
     };
 

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
@@ -1,12 +1,12 @@
 #include "z_kaleido_scope.h"
 
 #include "libu64/gfxprint.h"
-#include "config.h"
 #include "controller.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"
 #include "gfxalloc.h"
 #include "printf.h"
+#include "translation.h"
 #include "z64play.h"
 #include "z64save.h"
 
@@ -49,48 +49,40 @@ void KaleidoScope_DrawDebugEditorText(Gfx** gfxP) {
     GfxPrint printer;
     s32 pad[2];
 
-    static bool JPN = false;
-
-#if OOT_NTSC
-    if (gSaveContext.language == LANGUAGE_JPN) {
-        JPN = true;
-    }
-#endif
-
     GfxPrint_Init(&printer);
     GfxPrint_Open(&printer, *gfxP);
 
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 2);
     GfxPrint_SetColor(&printer, 255, 60, 0, 255);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ﾙﾋﾟｰ") : "Rup"); // "Rupee"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ﾙﾋﾟｰ", "Rup")); // "Rupee"
     GfxPrint_SetPos(&printer, 15 - (WIDESCREEN ? 1 : 0), 2);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ﾊｰﾄ") : " HP"); // "Heart"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ﾊｰﾄ", " HP")); // "Heart"
     GfxPrint_SetPos(&printer, 26 - (WIDESCREEN ? 1 : 0), 3);
     GfxPrint_Printf(&printer, "%s", "/4");
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 5);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ｱｲﾃﾑ") : "Item" ); // "Item"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ｱｲﾃﾑ", "Item" )); // "Item"
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 13);
-    GfxPrint_Printf(&printer, "%s", JPN ? "KEY" : "Key");
+    GfxPrint_Printf(&printer, "%s", T("KEY", "Key"));
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 15);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_HIRAGANA "ｿｳﾋﾞ") : "Gear" ); // "Equipment"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_HIRAGANA "ｿｳﾋﾞ", "Gear" )); // "Equipment"
     GfxPrint_SetPos(&printer, 23 - (WIDESCREEN ? 1 : 0), 14);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ｹﾝ") : "Sw" ); // "Sword"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ｹﾝ", "Sw" )); // "Sword"
     GfxPrint_SetPos(&printer, 23 - (WIDESCREEN ? 1 : 0), 15);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ﾀﾃ") : "Sh" ); // "Shield"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ﾀﾃ", "Sh" )); // "Shield"
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 17);
-    GfxPrint_Printf(&printer, "%s", JPN ? "MAP" : "Map");
+    GfxPrint_Printf(&printer, "%s", T("MAP", "Map"));
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 19);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_HIRAGANA "ﾌｳｲﾝ") : "Medal" ); // "Seal"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_HIRAGANA "ﾌｳｲﾝ", "Medal" )); // "Seal"
     GfxPrint_SetPos(&printer, 20 - (WIDESCREEN ? 1 : 0), 19);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_HIRAGANA "ｾｲﾚｲｾｷ") : "Stone" ); // "Spiritual Stone"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_HIRAGANA "ｾｲﾚｲｾｷ", "Stone" )); // "Spiritual Stone"
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 21);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ｵｶﾘﾅ") : "Song" ); // "Ocarina"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ｵｶﾘﾅ", "Song" )); // "Ocarina"
     GfxPrint_SetPos(&printer, 4 - (WIDESCREEN ? 1 : 0), 24);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ｺﾚｸﾄ") : "Misc" ); // "Collect"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ｺﾚｸﾄ", "Misc" )); // "Collect"
     GfxPrint_SetPos(&printer, 14 - (WIDESCREEN ? 1 : 0), 24);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ｷﾝｽﾀ") : "  GS" ); // "Skulltula"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ｷﾝｽﾀ", "  GS" )); // "Skulltula"
     GfxPrint_SetPos(&printer, 23 - (WIDESCREEN ? 1 : 0), 24);
-    GfxPrint_Printf(&printer, "%s", JPN ? (GFXP_KATAKANA "ｶｹﾗ") : "PoH" ); // "Gold Token"
+    GfxPrint_Printf(&printer, "%s", T(GFXP_KATAKANA "ｶｹﾗ", "PoH" )); // "Gold Token"
     GfxPrint_SetPos(&printer, 28 - (WIDESCREEN ? 1 : 0), 24);
     GfxPrint_Printf(&printer, "%s", "/4");
 


### PR DESCRIPTION
Use decomp translation macro and default to English for said macro. PRINTF is now logged in English as well, which is arguably more useful than logging Japanese into an IS64 viewer that likely doesn't use proper character encoding in the first place.