### PR TITLE
Debug: Skip checking for controller 2

### DIFF
--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -462,7 +462,7 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
     }
 
 #if DEBUG_FEATURES
-    if (gIsCtrlr2Valid && CHECK_BTN_ALL(gameState->input[0].press.button, BTN_Z) &&
+    if (CHECK_BTN_ALL(gameState->input[0].press.button, BTN_Z) &&
         CHECK_BTN_ALL(gameState->input[0].cur.button, BTN_L | BTN_R)) {
         gSaveContext.gameMode = GAMEMODE_NORMAL;
         SET_NEXT_GAMESTATE(gameState, MapSelect_Init, MapSelectState);

--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -171,7 +171,7 @@ void ConsoleLogo_Main(GameState* thisx) {
     ConsoleLogo_Draw(this);
 
 #if DEBUG_FEATURES
-    if (gIsCtrlr2Valid) {
+    if (1) {
         Gfx* gfx = POLY_OPA_DISP;
 
         ConsoleLogo_PrintBuildInfo(&gfx);


### PR DESCRIPTION
Display the build info and allow doing the button combo for the map select without a plugged in controller in port 2.
Simplifies testing, especially on real hardware.