### PR TITLE
Final Ganon Boss object optimizations

### DIFF
--- a/assets/objects/object_ganon2/object_ganon2.c
+++ b/assets/objects/object_ganon2/object_ganon2.c
@@ -1,0 +1,970 @@
+#include "assets/objects/object_ganon2/object_ganon2.h"
+
+#include "array_count.h"
+#include "gfx.h"
+#include "sys_matrix.h"
+#include "ultra64.h"
+
+s16 gGanonFinalBlowFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonFinalBlowFrameData.inc.c"
+};
+
+JointIndex gGanonFinalBlowJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonFinalBlowJointIndices.inc.c"
+};
+
+AnimationHeader gGanonFinalBlowAnim = {
+#include "assets/objects/object_ganon2/gGanonFinalBlowAnim.inc.c"
+};
+
+s16 gGanonDeadStartFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonDeadStartFrameData.inc.c"
+};
+
+JointIndex gGanonDeadStartJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonDeadStartJointIndices.inc.c"
+};
+
+AnimationHeader gGanonDeadStartAnim = {
+#include "assets/objects/object_ganon2/gGanonDeadStartAnim.inc.c"
+};
+
+s16 gGanonDeadLoopFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonDeadLoopFrameData.inc.c"
+};
+
+JointIndex gGanonDeadLoopJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonDeadLoopJointIndices.inc.c"
+};
+
+AnimationHeader gGanonDeadLoopAnim = {
+#include "assets/objects/object_ganon2/gGanonDeadLoopAnim.inc.c"
+};
+
+s16 gGanonGuardToWalk_06008ED0_FrameData[] = {
+#include "assets/objects/object_ganon2/gGanonGuardToWalk_06008ED0_FrameData.inc.c"
+};
+
+JointIndex gGanonGuardToWalk_06009538_JointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonGuardToWalk_06009538_JointIndices.inc.c"
+};
+
+AnimationHeader gGanonGuardToWalk = {
+#include "assets/objects/object_ganon2/gGanonGuardToWalk.inc.c"
+};
+
+s16 gGanonLeftSwordSwingFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonLeftSwordSwingFrameData.inc.c"
+};
+
+JointIndex gGanonLeftSwordSwingJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonLeftSwordSwingJointIndices.inc.c"
+};
+
+AnimationHeader gGanonLeftSwordSwingAnim = {
+#include "assets/objects/object_ganon2/gGanonLeftSwordSwingAnim.inc.c"
+};
+
+s16 gGanonRightSwordSwingFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonRightSwordSwingFrameData.inc.c"
+};
+
+JointIndex gGanonRightSwordSwingJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonRightSwordSwingJointIndices.inc.c"
+};
+
+AnimationHeader gGanonRightSwordSwingAnim = {
+#include "assets/objects/object_ganon2/gGanonRightSwordSwingAnim.inc.c"
+};
+
+s16 gGanonDamageFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonDamageFrameData.inc.c"
+};
+
+JointIndex gGanonDamageJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonDamageJointIndices.inc.c"
+};
+
+AnimationHeader gGanonDamageAnim = {
+#include "assets/objects/object_ganon2/gGanonDamageAnim.inc.c"
+};
+
+s16 gGanonGuardWalkFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonGuardWalkFrameData.inc.c"
+};
+
+JointIndex gGanonGuardWalkJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonGuardWalkJointIndices.inc.c"
+};
+
+AnimationHeader gGanonGuardWalkAnim = {
+#include "assets/objects/object_ganon2/gGanonGuardWalkAnim.inc.c"
+};
+
+s16 gGanonGuardSidestepFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonGuardSidestepFrameData.inc.c"
+};
+
+JointIndex gGanonGuardSidestepJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonGuardSidestepJointIndices.inc.c"
+};
+
+AnimationHeader gGanonGuardSidestepAnim = {
+#include "assets/objects/object_ganon2/gGanonGuardSidestepAnim.inc.c"
+};
+
+s16 gGanonGuardIdleFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonGuardIdleFrameData.inc.c"
+};
+
+JointIndex gGanonGuardIdleJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonGuardIdleJointIndices.inc.c"
+};
+
+AnimationHeader gGanonGuardIdleAnim = {
+#include "assets/objects/object_ganon2/gGanonGuardIdleAnim.inc.c"
+};
+
+Vtx gGanonRightHair3Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightHair3Vtx.inc.c"
+};
+
+Vtx gGanonRightHair2Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightHair2Vtx.inc.c"
+};
+
+Vtx gGanonRightHair1Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightHair1Vtx.inc.c"
+};
+
+Vtx gGanonLeftHair3Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftHair3Vtx.inc.c"
+};
+
+Vtx gGanonLeftHair2Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftHair2Vtx.inc.c"
+};
+
+Vtx gGanonLeftHair1Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftHair1Vtx.inc.c"
+};
+
+Vtx gGanonMiddleHair3Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair3Vtx.inc.c"
+};
+
+Vtx gGanonMiddleHair2Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair2Vtx.inc.c"
+};
+
+Vtx gGanonMiddleHair1Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair1Vtx.inc.c"
+};
+
+Vtx gGanonJawVtx[] = {
+#include "assets/objects/object_ganon2/gGanonJawVtx.inc.c"
+};
+
+Vtx gGanonMouthVtx[] = {
+#include "assets/objects/object_ganon2/gGanonMouthVtx.inc.c"
+};
+
+Vtx gGanonSnoutVtx[] = {
+#include "assets/objects/object_ganon2/gGanonSnoutVtx.inc.c"
+};
+
+Vtx gGanonHeadVtx[] = {
+#include "assets/objects/object_ganon2/gGanonHeadVtx.inc.c"
+};
+
+Vtx gGanonNeckVtx[] = {
+#include "assets/objects/object_ganon2/gGanonNeckVtx.inc.c"
+};
+
+Vtx gGanonRightWristVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightWristVtx.inc.c"
+};
+
+Vtx gGanonRightForearmVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightForearmVtx.inc.c"
+};
+
+Vtx gGanonRightUpperArmVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightUpperArmVtx.inc.c"
+};
+
+Vtx gGanonRightShoulderVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightShoulderVtx.inc.c"
+};
+
+Vtx gGanonLeftWristVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftWristVtx.inc.c"
+};
+
+Vtx gGanonLeftForearmVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftForearmVtx.inc.c"
+};
+
+Vtx gGanonLeftUpperArmVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftUpperArmVtx.inc.c"
+};
+
+Vtx gGanonLeftShoulderVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftShoulderVtx.inc.c"
+};
+
+Vtx gGanonTorsoVtx[] = {
+#include "assets/objects/object_ganon2/gGanonTorsoVtx.inc.c"
+};
+
+Vtx gGanonLeftFootVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftFootVtx.inc.c"
+};
+
+Vtx gGanonLeftShinVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftShinVtx.inc.c"
+};
+
+Vtx gGanonLeftThighVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftThighVtx.inc.c"
+};
+
+Vtx gGanonRightFootVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightFootVtx.inc.c"
+};
+
+Vtx gGanonRightShinVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightShinVtx.inc.c"
+};
+
+Vtx gGanonRightThighVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightThighVtx.inc.c"
+};
+
+Vtx gGanonTail1Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonTail1Vtx.inc.c"
+};
+
+Vtx gGanonTail2Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonTail2Vtx.inc.c"
+};
+
+Vtx gGanonTail3Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonTail3Vtx.inc.c"
+};
+
+Vtx gGanonTail4Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonTail4Vtx.inc.c"
+};
+
+Vtx gGanonTail5Vtx[] = {
+#include "assets/objects/object_ganon2/gGanonTail5Vtx.inc.c"
+};
+
+Vtx gGanonPelvisVtx[] = {
+#include "assets/objects/object_ganon2/gGanonPelvisVtx.inc.c"
+};
+
+Gfx gGanonPelvisDL[72] = {
+#include "assets/objects/object_ganon2/gGanonPelvisDL.inc.c"
+};
+
+Gfx gGanonTail1DL[34] = {
+#include "assets/objects/object_ganon2/gGanonTail1DL.inc.c"
+};
+
+Gfx gGanonTail2DL[52] = {
+#include "assets/objects/object_ganon2/gGanonTail2DL.inc.c"
+};
+
+Gfx gGanonTail3DL[57] = {
+#include "assets/objects/object_ganon2/gGanonTail3DL.inc.c"
+};
+
+Gfx gGanonTail4DL[40] = {
+#include "assets/objects/object_ganon2/gGanonTail4DL.inc.c"
+};
+
+Gfx gGanonTail5DL[37] = {
+#include "assets/objects/object_ganon2/gGanonTail5DL.inc.c"
+};
+
+Gfx gGanonRightShinDL[78] = {
+#include "assets/objects/object_ganon2/gGanonRightShinDL.inc.c"
+};
+
+Gfx gGanonRightFootDL[60] = {
+#include "assets/objects/object_ganon2/gGanonRightFootDL.inc.c"
+};
+
+Gfx gGanonRightThighDL[152] = {
+#include "assets/objects/object_ganon2/gGanonRightThighDL.inc.c"
+};
+
+Gfx gGanonLeftShinDL[94] = {
+#include "assets/objects/object_ganon2/gGanonLeftShinDL.inc.c"
+};
+
+Gfx gGanonLeftFootDL[60] = {
+#include "assets/objects/object_ganon2/gGanonLeftFootDL.inc.c"
+};
+
+Gfx gGanonLeftThighDL[152] = {
+#include "assets/objects/object_ganon2/gGanonLeftThighDL.inc.c"
+};
+
+Gfx gGanonNeckDL[38] = {
+#include "assets/objects/object_ganon2/gGanonNeckDL.inc.c"
+};
+
+Gfx gGanonHeadDL[174] = {
+#include "assets/objects/object_ganon2/gGanonHeadDL.inc.c"
+};
+
+Gfx gGanonRightHair3DL[30] = {
+#include "assets/objects/object_ganon2/gGanonRightHair3DL.inc.c"
+};
+
+Gfx gGanonRightHair2DL[29] = {
+#include "assets/objects/object_ganon2/gGanonRightHair2DL.inc.c"
+};
+
+Gfx gGanonRightHair1DL[22] = {
+#include "assets/objects/object_ganon2/gGanonRightHair1DL.inc.c"
+};
+
+Gfx gGanonLeftHair3DL[30] = {
+#include "assets/objects/object_ganon2/gGanonLeftHair3DL.inc.c"
+};
+
+Gfx gGanonLeftHair2DL[29] = {
+#include "assets/objects/object_ganon2/gGanonLeftHair2DL.inc.c"
+};
+
+Gfx gGanonLeftHair1DL[22] = {
+#include "assets/objects/object_ganon2/gGanonLeftHair1DL.inc.c"
+};
+
+Gfx gGanonJawDL[104] = {
+#include "assets/objects/object_ganon2/gGanonJawDL.inc.c"
+};
+
+Gfx gGanonMouthDL[110] = {
+#include "assets/objects/object_ganon2/gGanonMouthDL.inc.c"
+};
+
+Gfx gGanonSnoutDL[36] = {
+#include "assets/objects/object_ganon2/gGanonSnoutDL.inc.c"
+};
+
+Gfx gGanonMiddleHair3DL[30] = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair3DL.inc.c"
+};
+
+Gfx gGanonMiddleHair2DL[30] = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair2DL.inc.c"
+};
+
+Gfx gGanonMiddleHair1DL[22] = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair1DL.inc.c"
+};
+
+Gfx gGanonTorsoDL[144] = {
+#include "assets/objects/object_ganon2/gGanonTorsoDL.inc.c"
+};
+
+Gfx gGanonRightShoulderDL[69] = {
+#include "assets/objects/object_ganon2/gGanonRightShoulderDL.inc.c"
+};
+
+Gfx gGanonRightForearmDL[92] = {
+#include "assets/objects/object_ganon2/gGanonRightForearmDL.inc.c"
+};
+
+Gfx gGanonRightWristDL[33] = {
+#include "assets/objects/object_ganon2/gGanonRightWristDL.inc.c"
+};
+
+Gfx gGanonRightUpperArmDL[146] = {
+#include "assets/objects/object_ganon2/gGanonRightUpperArmDL.inc.c"
+};
+
+Gfx gGanonLeftShoulderDL[69] = {
+#include "assets/objects/object_ganon2/gGanonLeftShoulderDL.inc.c"
+};
+
+Gfx gGanonLeftForearmDL[92] = {
+#include "assets/objects/object_ganon2/gGanonLeftForearmDL.inc.c"
+};
+
+Gfx gGanonLeftWristDL[33] = {
+#include "assets/objects/object_ganon2/gGanonLeftWristDL.inc.c"
+};
+
+Gfx gGanonLeftUpperArmDL[146] = {
+#include "assets/objects/object_ganon2/gGanonLeftUpperArmDL.inc.c"
+};
+
+u64 gGanonBodyTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonBodyTex.tlut.rgba16.inc.c"
+};
+
+u64 gGanonHairFringeTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonHairFringeTex.tlut.rgba16.inc.c"
+};
+
+u64 gGanonGerudoFabricTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonGerudoFabricTex.tlut.rgba16.inc.c"
+};
+
+u64 gGanonRedFabricTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonRedFabricTLUT.tlut.rgba16.inc.c"
+};
+
+u64 gGanonBlackLeatherAndPauldronTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonBlackLeatherAndPauldronTLUT.tlut.rgba16.inc.c"
+};
+
+u64 gGanonLeatherTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonLeatherTex.tlut.rgba16.inc.c"
+};
+
+u64 gGanonHoofTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonHoofTex.tlut.rgba16.inc.c"
+};
+
+u64 gGanonTailTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonTailTex.tlut.rgba16.inc.c"
+};
+
+u64 gGanonHairTex[TEX_LEN(u64, gGanonHairTex_WIDTH, gGanonHairTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonHairTex.rgba16.inc.c"
+};
+
+u64 gGanonMouthTex[TEX_LEN(u64, gGanonMouthTex_WIDTH, gGanonMouthTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonMouthTex.rgba16.inc.c"
+};
+
+u64 gGanonFacialHairTex[TEX_LEN(u64, gGanonFacialHairTex_WIDTH, gGanonFacialHairTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonFacialHairTex.rgba16.inc.c"
+};
+
+u64 gGanonBodyTex[TEX_LEN(u64, gGanonBodyTex_WIDTH, gGanonBodyTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonBodyTex.ci8.inc.c"
+};
+
+u64 gGanonSnoutFrontTex[TEX_LEN(u64, gGanonSnoutFrontTex_WIDTH, gGanonSnoutFrontTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonSnoutFrontTex.rgba16.inc.c"
+};
+
+u64 gGanonSnoutSideTex[TEX_LEN(u64, gGanonSnoutSideTex_WIDTH, gGanonSnoutSideTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonSnoutSideTex.rgba16.inc.c"
+};
+
+u64 gGanonHairFringeTex[TEX_LEN(u64, gGanonHairFringeTex_WIDTH, gGanonHairFringeTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonHairFringeTex.ci8.inc.c"
+};
+
+u64 gGanonGerudoFabricTex[TEX_LEN(u64, gGanonGerudoFabricTex_WIDTH, gGanonGerudoFabricTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonGerudoFabricTex.ci8.inc.c"
+};
+
+u64 gGanonFurTuftTex[TEX_LEN(u64, gGanonFurTuftTex_WIDTH, gGanonFurTuftTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonFurTuftTex.rgba16.inc.c"
+};
+
+u64 gGanonRedFabricTex[TEX_LEN(u64, gGanonRedFabricTex_WIDTH, gGanonRedFabricTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonRedFabricTex.ci8.tlut_gGanonRedFabricTLUT.inc.c"
+};
+
+u64 gGanonPauldronTex[TEX_LEN(u64, gGanonPauldronTex_WIDTH, gGanonPauldronTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonPauldronTex.ci8.tlut_gGanonBlackLeatherAndPauldronTLUT.inc.c"
+};
+
+u64 gGanonCapeFasteningTex[TEX_LEN(u64, gGanonCapeFasteningTex_WIDTH, gGanonCapeFasteningTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonCapeFasteningTex.ci8.tlut_gGanonRedFabricTLUT.inc.c"
+};
+
+u64 gGanonBlackLeatherTex[TEX_LEN(u64, gGanonBlackLeatherTex_WIDTH, gGanonBlackLeatherTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonBlackLeatherTex.ci8.tlut_gGanonBlackLeatherAndPauldronTLUT.inc.c"
+};
+
+u64 gGanonLeatherTex[TEX_LEN(u64, gGanonLeatherTex_WIDTH, gGanonLeatherTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonLeatherTex.ci8.inc.c"
+};
+
+u64 gGanonHoofTex[TEX_LEN(u64, gGanonHoofTex_WIDTH, gGanonHoofTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonHoofTex.ci8.inc.c"
+};
+
+u64 gGanonUnderSkirtTex[TEX_LEN(u64, gGanonUnderSkirtTex_WIDTH, gGanonUnderSkirtTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonUnderSkirtTex.rgba16.inc.c"
+};
+
+u64 gGanonTailTex[TEX_LEN(u64, gGanonTailTex_WIDTH, gGanonTailTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonTailTex.ci8.inc.c"
+};
+
+u64 gGanonEyesTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonEyesTLUT.tlut.rgba16.inc.c"
+};
+
+u64 gGanonHandTLUT[] = {
+#include "assets/objects/object_ganon2/gGanonHandTex.tlut.rgba16.inc.c"
+};
+
+u64 gGanonHandTex[TEX_LEN(u64, gGanonHandTex_WIDTH, gGanonHandTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonHandTex.ci8.inc.c"
+};
+
+u64 gGanonJewelTex[TEX_LEN(u64, gGanonJewelTex_WIDTH, gGanonJewelTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonJewelTex.rgba16.inc.c"
+};
+
+u64 gGanonClawAndTeethTex[TEX_LEN(u64, gGanonClawAndTeethTex_WIDTH, gGanonClawAndTeethTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonClawAndTeethTex.rgba16.inc.c"
+};
+
+u64 gGanonEyeOpenTex[TEX_LEN(u64, gGanonEyeOpenTex_WIDTH, gGanonEyeOpenTex_HEIGHT, 4)] = {
+#include "assets/objects/object_ganon2/gGanonEyeOpenTex.ci4.tlut_gGanonEyesTLUT.inc.c"
+};
+
+u64 gGanonLipsTex[TEX_LEN(u64, gGanonLipsTex_WIDTH, gGanonLipsTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonLipsTex.rgba16.inc.c"
+};
+
+u64 gGanonHornBaseTex[TEX_LEN(u64, gGanonHornBaseTex_WIDTH, gGanonHornBaseTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonHornBaseTex.rgba16.inc.c"
+};
+
+u64 gGanonHornTex[TEX_LEN(u64, gGanonHornTex_WIDTH, gGanonHornTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonHornTex.rgba16.inc.c"
+};
+
+u64 gGanonSwordBladeTex[TEX_LEN(u64, gGanonSwordBladeTex_WIDTH, gGanonSwordBladeTex_HEIGHT, 4)] = {
+#include "assets/objects/object_ganon2/gGanonSwordBladeTex.i4.inc.c"
+};
+
+u64 gGanonSwordGuardTex[TEX_LEN(u64, gGanonSwordGuardTex_WIDTH, gGanonSwordGuardTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonSwordGuardTex.rgba16.inc.c"
+};
+
+u64 gGanonSwordGripTex[TEX_LEN(u64, gGanonSwordGripTex_WIDTH, gGanonSwordGripTex_HEIGHT, 16)] = {
+#include "assets/objects/object_ganon2/gGanonSwordGripTex.rgba16.inc.c"
+};
+
+u64 gGanonEyeHalfTex[TEX_LEN(u64, gGanonEyeHalfTex_WIDTH, gGanonEyeHalfTex_HEIGHT, 4)] = {
+#include "assets/objects/object_ganon2/gGanonEyeHalfTex.ci4.tlut_gGanonEyesTLUT.inc.c"
+};
+
+u64 gGanonEyeClosedTex[TEX_LEN(u64, gGanonEyeClosedTex_WIDTH, gGanonEyeClosedTex_HEIGHT, 4)] = {
+#include "assets/objects/object_ganon2/gGanonEyeClosedTex.ci4.tlut_gGanonEyesTLUT.inc.c"
+};
+
+Vtx gGanonEyesVtx[] = {
+#include "assets/objects/object_ganon2/gGanonEyesVtx.inc.c"
+};
+
+Vtx gGanonJewelVtx[] = {
+#include "assets/objects/object_ganon2/gGanonJewelVtx.inc.c"
+};
+
+Vtx gGanonRightHornVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightHornVtx.inc.c"
+};
+
+Vtx gGanonLeftHornVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftHornVtx.inc.c"
+};
+
+Vtx gGanonRightHandVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightHandVtx.inc.c"
+};
+
+Vtx gGanonLeftHandVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftHandVtx.inc.c"
+};
+
+Vtx gGanonRightSwordVtx[] = {
+#include "assets/objects/object_ganon2/gGanonRightSwordVtx.inc.c"
+};
+
+Vtx gGanonLeftSwordVtx[] = {
+#include "assets/objects/object_ganon2/gGanonLeftSwordVtx.inc.c"
+};
+
+Vtx gGanonOuterTeethVtx[] = {
+#include "assets/objects/object_ganon2/gGanonOuterTeethVtx.inc.c"
+};
+
+Vtx gGanonInnerTeethVtx[] = {
+#include "assets/objects/object_ganon2/gGanonInnerTeethVtx.inc.c"
+};
+
+Gfx gGanonEyesDL[25] = {
+#include "assets/objects/object_ganon2/gGanonEyesDL.inc.c"
+};
+
+Gfx gGanonJewelDL[20] = {
+#include "assets/objects/object_ganon2/gGanonJewelDL.inc.c"
+};
+
+Gfx gGanonRightHornDL[45] = {
+#include "assets/objects/object_ganon2/gGanonRightHornDL.inc.c"
+};
+
+Gfx gGanonLeftHornDL[45] = {
+#include "assets/objects/object_ganon2/gGanonLeftHornDL.inc.c"
+};
+
+Gfx gGanonRightHandDL[58] = {
+#include "assets/objects/object_ganon2/gGanonRightHandDL.inc.c"
+};
+
+Gfx gGanonLeftHandDL[58] = {
+#include "assets/objects/object_ganon2/gGanonLeftHandDL.inc.c"
+};
+
+Gfx gGanonRightSwordDL[92] = {
+#include "assets/objects/object_ganon2/gGanonRightSwordDL.inc.c"
+};
+
+Gfx gGanonLeftSwordDL[93] = {
+#include "assets/objects/object_ganon2/gGanonLeftSwordDL.inc.c"
+};
+
+Gfx gGanonOuterTeethDL[36] = {
+#include "assets/objects/object_ganon2/gGanonOuterTeethDL.inc.c"
+};
+
+Gfx gGanonInnerTeethDL[23] = {
+#include "assets/objects/object_ganon2/gGanonInnerTeethDL.inc.c"
+};
+
+u64 gGanonTitleCardTex[TEX_LEN(u64, gGanonTitleCardTex_WIDTH, gGanonTitleCardTex_HEIGHT, 8)] = {
+#include "assets/objects/object_ganon2/gGanonTitleCardTex.ia8.inc.c"
+};
+
+StandardLimb gGanonRootLimb = {
+#include "assets/objects/object_ganon2/gGanonRootLimb.inc.c"
+};
+
+StandardLimb gGanonTorsoLimb = {
+#include "assets/objects/object_ganon2/gGanonTorsoLimb.inc.c"
+};
+
+StandardLimb gGanonLeftShoulderLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftShoulderLimb.inc.c"
+};
+
+StandardLimb gGanonLeftUpperArmLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftUpperArmLimb.inc.c"
+};
+
+StandardLimb gGanonLeftForearmLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftForearmLimb.inc.c"
+};
+
+StandardLimb gGanonLeftWristLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftWristLimb.inc.c"
+};
+
+StandardLimb gGanonLeftSwordLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftSwordLimb.inc.c"
+};
+
+StandardLimb gGanonLeftHandLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftHandLimb.inc.c"
+};
+
+StandardLimb gGanonRightShoulderLimb = {
+#include "assets/objects/object_ganon2/gGanonRightShoulderLimb.inc.c"
+};
+
+StandardLimb gGanonRightUpperArmLimb = {
+#include "assets/objects/object_ganon2/gGanonRightUpperArmLimb.inc.c"
+};
+
+StandardLimb gGanonRightForearmLimb = {
+#include "assets/objects/object_ganon2/gGanonRightForearmLimb.inc.c"
+};
+
+StandardLimb gGanonRightWristLimb = {
+#include "assets/objects/object_ganon2/gGanonRightWristLimb.inc.c"
+};
+
+StandardLimb gGanonRightSwordLimb = {
+#include "assets/objects/object_ganon2/gGanonRightSwordLimb.inc.c"
+};
+
+StandardLimb gGanonRightHandLimb = {
+#include "assets/objects/object_ganon2/gGanonRightHandLimb.inc.c"
+};
+
+StandardLimb gGanonNeckLimb = {
+#include "assets/objects/object_ganon2/gGanonNeckLimb.inc.c"
+};
+
+StandardLimb gGanonJewelLimb = {
+#include "assets/objects/object_ganon2/gGanonJewelLimb.inc.c"
+};
+
+StandardLimb gGanonSnoutLimb = {
+#include "assets/objects/object_ganon2/gGanonSnoutLimb.inc.c"
+};
+
+StandardLimb gGanonOuterTeethLimb = {
+#include "assets/objects/object_ganon2/gGanonOuterTeethLimb.inc.c"
+};
+
+StandardLimb gGanonMouthLimb = {
+#include "assets/objects/object_ganon2/gGanonMouthLimb.inc.c"
+};
+
+StandardLimb gGanonInnerTeethLimb = {
+#include "assets/objects/object_ganon2/gGanonInnerTeethLimb.inc.c"
+};
+
+StandardLimb gGanonJawLimb = {
+#include "assets/objects/object_ganon2/gGanonJawLimb.inc.c"
+};
+
+StandardLimb gGanonMiddleHair1Limb = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair1Limb.inc.c"
+};
+
+StandardLimb gGanonMiddleHair2Limb = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair2Limb.inc.c"
+};
+
+StandardLimb gGanonMiddleHair3Limb = {
+#include "assets/objects/object_ganon2/gGanonMiddleHair3Limb.inc.c"
+};
+
+StandardLimb gGanonLeftHair1Limb = {
+#include "assets/objects/object_ganon2/gGanonLeftHair1Limb.inc.c"
+};
+
+StandardLimb gGanonLeftHair2Limb = {
+#include "assets/objects/object_ganon2/gGanonLeftHair2Limb.inc.c"
+};
+
+StandardLimb gGanonLeftHair3Limb = {
+#include "assets/objects/object_ganon2/gGanonLeftHair3Limb.inc.c"
+};
+
+StandardLimb gGanonRightHair1Limb = {
+#include "assets/objects/object_ganon2/gGanonRightHair1Limb.inc.c"
+};
+
+StandardLimb gGanonRightHair2Limb = {
+#include "assets/objects/object_ganon2/gGanonRightHair2Limb.inc.c"
+};
+
+StandardLimb gGanonRightHair3Limb = {
+#include "assets/objects/object_ganon2/gGanonRightHair3Limb.inc.c"
+};
+
+StandardLimb gGanonEyesLimb = {
+#include "assets/objects/object_ganon2/gGanonEyesLimb.inc.c"
+};
+
+StandardLimb gGanonHeadLimb = {
+#include "assets/objects/object_ganon2/gGanonHeadLimb.inc.c"
+};
+
+StandardLimb gGanonLeftHornLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftHornLimb.inc.c"
+};
+
+StandardLimb gGanonRightHornLimb = {
+#include "assets/objects/object_ganon2/gGanonRightHornLimb.inc.c"
+};
+
+StandardLimb gGanonPelvisLimb = {
+#include "assets/objects/object_ganon2/gGanonPelvisLimb.inc.c"
+};
+
+StandardLimb gGanonLeftThighLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftThighLimb.inc.c"
+};
+
+StandardLimb gGanonLeftShinLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftShinLimb.inc.c"
+};
+
+StandardLimb gGanonLeftFootLimb = {
+#include "assets/objects/object_ganon2/gGanonLeftFootLimb.inc.c"
+};
+
+StandardLimb gGanonRightThighLimb = {
+#include "assets/objects/object_ganon2/gGanonRightThighLimb.inc.c"
+};
+
+StandardLimb gGanonRightShinLimb = {
+#include "assets/objects/object_ganon2/gGanonRightShinLimb.inc.c"
+};
+
+StandardLimb gGanonRightFootLimb = {
+#include "assets/objects/object_ganon2/gGanonRightFootLimb.inc.c"
+};
+
+StandardLimb gGanonTail1Limb = {
+#include "assets/objects/object_ganon2/gGanonTail1Limb.inc.c"
+};
+
+StandardLimb gGanonTail2Limb = {
+#include "assets/objects/object_ganon2/gGanonTail2Limb.inc.c"
+};
+
+StandardLimb gGanonTail3Limb = {
+#include "assets/objects/object_ganon2/gGanonTail3Limb.inc.c"
+};
+
+StandardLimb gGanonTail4Limb = {
+#include "assets/objects/object_ganon2/gGanonTail4Limb.inc.c"
+};
+
+StandardLimb gGanonTail5Limb = {
+#include "assets/objects/object_ganon2/gGanonTail5Limb.inc.c"
+};
+
+void* gGanonSkel_060244B8_Limbs[] = {
+#include "assets/objects/object_ganon2/gGanonSkel_060244B8_Limbs.inc.c"
+};
+
+FlexSkeletonHeader gGanonSkel = {
+#include "assets/objects/object_ganon2/gGanonSkel.inc.c"
+};
+
+s16 gGanonStunStartFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonStunStartFrameData.inc.c"
+};
+
+JointIndex gGanonStunStartJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonStunStartJointIndices.inc.c"
+};
+
+AnimationHeader gGanonStunStartAnim = {
+#include "assets/objects/object_ganon2/gGanonStunStartAnim.inc.c"
+};
+
+s16 gGanonStunLoopFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonStunLoopFrameData.inc.c"
+};
+
+JointIndex gGanonStunLoopJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonStunLoopJointIndices.inc.c"
+};
+
+AnimationHeader gGanonStunLoopAnim = {
+#include "assets/objects/object_ganon2/gGanonStunLoopAnim.inc.c"
+};
+
+s16 gGanonStunEndFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonStunEndFrameData.inc.c"
+};
+
+JointIndex gGanonStunEndJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonStunEndJointIndices.inc.c"
+};
+
+AnimationHeader gGanonStunEndAnim = {
+#include "assets/objects/object_ganon2/gGanonStunEndAnim.inc.c"
+};
+
+s16 gGanonDownedStartFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonDownedStartFrameData.inc.c"
+};
+
+JointIndex gGanonDownedStartJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonDownedStartJointIndices.inc.c"
+};
+
+AnimationHeader gGanonDownedStartAnim = {
+#include "assets/objects/object_ganon2/gGanonDownedStartAnim.inc.c"
+};
+
+s16 gGanonStunEndToWalkFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonStunEndToWalkFrameData.inc.c"
+};
+
+JointIndex gGanonStunEndToWalkJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonStunEndToWalkJointIndices.inc.c"
+};
+
+AnimationHeader gGanonStunEndToWalkAnim = {
+#include "assets/objects/object_ganon2/gGanonStunEndToWalkAnim.inc.c"
+};
+
+s16 gGanonDuplicateStunStartFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonDuplicateStunStartFrameData.inc.c"
+};
+
+JointIndex gGanonDuplicateStunStartJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonDuplicateStunStartJointIndices.inc.c"
+};
+
+AnimationHeader gGanonDuplicateStunStartAnim = {
+#include "assets/objects/object_ganon2/gGanonDuplicateStunStartAnim.inc.c"
+};
+
+s16 gGanonDuplicateStunLoopFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonDuplicateStunLoopFrameData.inc.c"
+};
+
+JointIndex gGanonDuplicateStunLoopJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonDuplicateStunLoopJointIndices.inc.c"
+};
+
+AnimationHeader gGanonDuplicateStunLoopAnim = {
+#include "assets/objects/object_ganon2/gGanonDuplicateStunLoopAnim.inc.c"
+};
+
+s16 gGanonGetUpFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonGetUpFrameData.inc.c"
+};
+
+JointIndex gGanonGetUpJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonGetUpJointIndices.inc.c"
+};
+
+AnimationHeader gGanonGetUpAnim = {
+#include "assets/objects/object_ganon2/gGanonGetUpAnim.inc.c"
+};
+
+s16 gGanonDownedLoopFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonDownedLoopFrameData.inc.c"
+};
+
+JointIndex gGanonDownedLoopJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonDownedLoopJointIndices.inc.c"
+};
+
+AnimationHeader gGanonDownedLoopAnim = {
+#include "assets/objects/object_ganon2/gGanonDownedLoopAnim.inc.c"
+};
+
+s16 gGanonWalkFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonWalkFrameData.inc.c"
+};
+
+JointIndex gGanonWalkJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonWalkJointIndices.inc.c"
+};
+
+AnimationHeader gGanonWalkAnim = {
+#include "assets/objects/object_ganon2/gGanonWalkAnim.inc.c"
+};
+
+s16 gGanonWalkToGuardFrameData[] = {
+#include "assets/objects/object_ganon2/gGanonWalkToGuardFrameData.inc.c"
+};
+
+JointIndex gGanonWalkToGuardJointIndices[] = {
+#include "assets/objects/object_ganon2/gGanonWalkToGuardJointIndices.inc.c"
+};
+
+AnimationHeader gGanonWalkToGuardAnim = {
+#include "assets/objects/object_ganon2/gGanonWalkToGuardAnim.inc.c"
+};

--- a/assets/objects/object_gj/object_gj.c
+++ b/assets/objects/object_gj/object_gj.c
@@ -1,0 +1,272 @@
+#include "assets/objects/object_gj/object_gj.h"
+
+#include "array_count.h"
+#include "camera.h"
+#include "gfx.h"
+#include "stdbool.h"
+#include "sys_matrix.h"
+#include "ultra64.h"
+
+Vtx gGanonsCastleRubbleAroundArenaDL_06000000_Vtx_fused_[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL_06000000_Vtx_fused_.inc.c"
+};
+
+Gfx gGanonsCastleRubbleAroundArenaDL[148] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubbleAroundArenaBgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaBgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubbleAroundArenaSurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaSurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubbleAroundArenaPolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaPolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubbleAroundArenaVtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaVtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubbleAroundArenaCol = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaCol.inc.c"
+};
+
+Vtx gGanonsCastleRubble2DL_06001BA0_Vtx_fused_[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2DL_06001BA0_Vtx_fused_.inc.c"
+};
+
+Gfx gGanonsCastleRubble2DL[41] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2DL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubble2BgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2BgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubble2SurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2SurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubble2PolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2PolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubble2VtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2VtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubble2Col = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2Col.inc.c"
+};
+
+Vtx gGanonsCastleRubble3DL_06001FA0_Vtx_fused_[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3DL_06001FA0_Vtx_fused_.inc.c"
+};
+
+Gfx gGanonsCastleRubble3DL[53] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3DL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubble3BgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3BgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubble3SurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3SurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubble3PolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3PolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubble3VtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3VtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubble3Col = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3Col.inc.c"
+};
+
+Vtx gGanonsCastleRubble4DL_06002480_Vtx_fused_[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble4DL_06002480_Vtx_fused_.inc.c"
+};
+
+Gfx gGanonsCastleRubble4DL[41] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble4DL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubble4BgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble4BgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubble4SurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble4SurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubble4PolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble4PolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubble4VtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble4VtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubble4Col = {
+#include "assets/objects/object_gj/gGanonsCastleRubble4Col.inc.c"
+};
+
+Vtx gGanonsCastleRubble5DL_06002880_Vtx_fused_[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble5DL_06002880_Vtx_fused_.inc.c"
+};
+
+Gfx gGanonsCastleRubble5DL[53] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble5DL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubble5BgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble5BgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubble5SurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble5SurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubble5PolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble5PolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubble5VtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble5VtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubble5Col = {
+#include "assets/objects/object_gj/gGanonsCastleRubble5Col.inc.c"
+};
+
+Vtx gGanonsCastleRubble6DL_06002D60_Vtx[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble6DL_06002D60_Vtx.inc.c"
+};
+
+Gfx gGanonsCastleRubble6DL[21] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble6DL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubble6BgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble6BgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubble6SurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble6SurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubble6PolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble6PolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubble6VtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble6VtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubble6Col = {
+#include "assets/objects/object_gj/gGanonsCastleRubble6Col.inc.c"
+};
+
+Vtx gGanonsCastleRubble7DL_06003010_Vtx_fused_[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble7DL_06003010_Vtx_fused_.inc.c"
+};
+
+Gfx gGanonsCastleRubble7DL[41] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble7DL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubble7BgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble7BgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubble7SurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble7SurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubble7PolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble7PolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubble7VtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble7VtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubble7Col = {
+#include "assets/objects/object_gj/gGanonsCastleRubble7Col.inc.c"
+};
+
+Vtx gGanonsCastleRubbleTallDL_06003410_Vtx_fused_[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleTallDL_06003410_Vtx_fused_.inc.c"
+};
+
+Gfx gGanonsCastleRubbleTallDL[57] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleTallDL.inc.c"
+};
+
+BgCamInfo gGanonsCastleRubbleTallBgCamList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleTallBgCamList.inc.c"
+};
+
+SurfaceType gGanonsCastleRubbleTallSurfaceTypes[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleTallSurfaceTypes.inc.c"
+};
+
+CollisionPoly gGanonsCastleRubbleTallPolyList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleTallPolyList.inc.c"
+};
+
+Vec3s gGanonsCastleRubbleTallVtxList[] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleTallVtxList.inc.c"
+};
+
+CollisionHeader gGanonsCastleRubbleTallCol = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleTallCol.inc.c"
+};
+
+u64 gGanonsCastleRubbleAroundArenaDL_00003B20_Tex[TEX_LEN(u64, gGanonsCastleRubbleAroundArenaDL_00003B20_Tex_WIDTH, gGanonsCastleRubbleAroundArenaDL_00003B20_Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL_00003B20_Tex.ia8.inc.c"
+};
+
+u64 gGanonsCastleRubbleAroundArenaDL_00003C20_Tex[TEX_LEN(u64, gGanonsCastleRubbleAroundArenaDL_00003C20_Tex_WIDTH, gGanonsCastleRubbleAroundArenaDL_00003C20_Tex_HEIGHT, 4)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL_00003C20_Tex.i4.inc.c"
+};
+
+u64 gGanonsCastleRubbleAroundArenaDL_00003D20_Tex[TEX_LEN(u64, gGanonsCastleRubbleAroundArenaDL_00003D20_Tex_WIDTH, gGanonsCastleRubbleAroundArenaDL_00003D20_Tex_HEIGHT, 16)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL_00003D20_Tex.rgba16.inc.c"
+};
+
+u64 gGanonsCastleRubbleAroundArenaDL_00003F20_Tex[TEX_LEN(u64, gGanonsCastleRubbleAroundArenaDL_00003F20_Tex_WIDTH, gGanonsCastleRubbleAroundArenaDL_00003F20_Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL_00003F20_Tex.i8.inc.c"
+};
+
+u64 gGanonsCastleRubbleAroundArenaDL_00004F20_Tex[TEX_LEN(u64, gGanonsCastleRubbleAroundArenaDL_00004F20_Tex_WIDTH, gGanonsCastleRubbleAroundArenaDL_00004F20_Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL_00004F20_Tex.i8.inc.c"
+};
+
+u64 gGanonsCastleRubbleAroundArenaDL_00005F20_Tex[TEX_LEN(u64, gGanonsCastleRubbleAroundArenaDL_00005F20_Tex_WIDTH, gGanonsCastleRubbleAroundArenaDL_00005F20_Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubbleAroundArenaDL_00005F20_Tex.i8.inc.c"
+};
+
+u64 gGanonsCastleRubble2DL_00006F20_Tex[TEX_LEN(u64, gGanonsCastleRubble2DL_00006F20_Tex_WIDTH, gGanonsCastleRubble2DL_00006F20_Tex_HEIGHT, 4)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2DL_00006F20_Tex.i4.inc.c"
+};
+
+u64 gGanonsCastleRubble2DL_00007320_Tex[TEX_LEN(u64, gGanonsCastleRubble2DL_00007320_Tex_WIDTH, gGanonsCastleRubble2DL_00007320_Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble2DL_00007320_Tex.i8.inc.c"
+};
+
+u64 gGanonsCastleRubble3DL_00007720_Tex[TEX_LEN(u64, gGanonsCastleRubble3DL_00007720_Tex_WIDTH, gGanonsCastleRubble3DL_00007720_Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3DL_00007720_Tex.ia8.inc.c"
+};
+
+u64 gGanonsCastleRubble3DL_00007B20_Tex[TEX_LEN(u64, gGanonsCastleRubble3DL_00007B20_Tex_WIDTH, gGanonsCastleRubble3DL_00007B20_Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_gj/gGanonsCastleRubble3DL_00007B20_Tex.i8.inc.c"
+};

--- a/assets/objects/object_zl2/object_zl2.c
+++ b/assets/objects/object_zl2/object_zl2.c
@@ -1,0 +1,370 @@
+#include "assets/objects/object_zl2/object_zl2.h"
+
+#include "array_count.h"
+#include "gfx.h"
+#include "sys_matrix.h"
+#include "ultra64.h"
+
+u64 gZelda2_0TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_0TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2_1TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_1TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2_2TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_2TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb_0600EA58_DL_00000E00_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb_0600EA58_DL_00000E00_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb_0600EA58_DL_00000E00_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb_0600EA58_DL_00000E00_CITex.ci8.tlut_gZelda2_0TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb_0600E910_DL_00000F00_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb_0600E910_DL_00000F00_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb_0600E910_DL_00000F00_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb_0600E910_DL_00000F00_CITex.ci8.tlut_gZelda2_0TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00000F40_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00000F40_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00000F40_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00000F40_CITex.ci8.tlut_gZelda2_0TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001140_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001140_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001140_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001140_CITex.ci8.tlut_gZelda2_0TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001180_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001180_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001180_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001180_CITex.ci8.tlut_gZelda2_1TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001280_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001280_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001280_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL_00001280_CITex.ci8.tlut_gZelda2_1TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000012C0_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000012C0_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000012C0_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000012C0_CITex.ci8.tlut_gZelda2_0TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000016C0_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000016C0_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000016C0_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_000016C0_CITex.ci8.tlut_gZelda2_2TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001AC0_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001AC0_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001AC0_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001AC0_CITex.ci8.tlut_gZelda2_2TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001CC0_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001CC0_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001CC0_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL_00001CC0_CITex.ci8.tlut_gZelda2_2TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_000024C0_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_000024C0_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_000024C0_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_000024C0_CITex.ci8.tlut_gZelda2_1TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002500_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002500_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002500_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002500_CITex.ci8.tlut_gZelda2_1TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002600_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002600_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002600_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002600_CITex.ci8.tlut_gZelda2_2TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002700_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002700_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002700_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002700_CITex.ci8.tlut_gZelda2_2TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002740_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002740_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002740_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002740_CITex.ci8.tlut_gZelda2_2TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002780_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002780_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002780_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002780_CITex.ci8.tlut_gZelda2_2TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002880_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002880_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002880_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL_00002880_CITex.ci8.tlut_gZelda2_1TLUT.inc.c"
+};
+
+u64 gZelda2TriforceTex[TEX_LEN(u64, gZelda2TriforceTex_WIDTH, gZelda2TriforceTex_HEIGHT, 16)] = {
+#include "assets/objects/object_zl2/gZelda2TriforceTex.rgba16.inc.c"
+};
+
+u64 gZelda2EyesTLUT[] = {
+#include "assets/objects/object_zl2/gZelda2EyesTLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2_3TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_3TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2MouthTLUT[] = {
+#include "assets/objects/object_zl2/gZelda2MouthTLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2_4TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_4TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2EyeOpenTex[TEX_LEN(u64, gZelda2EyeOpenTex_WIDTH, gZelda2EyeOpenTex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2EyeOpenTex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_000034C8_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_000034C8_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_000034C8_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_000034C8_CITex.ci8.tlut_gZelda2_3TLUT.inc.c"
+};
+
+u64 gZelda2MouthSeriousTex[TEX_LEN(u64, gZelda2MouthSeriousTex_WIDTH, gZelda2MouthSeriousTex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2MouthSeriousTex.ci8.tlut_gZelda2MouthTLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003908_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003908_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003908_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003908_CITex.ci8.tlut_gZelda2_3TLUT.inc.c"
+};
+
+u64 gZelda2Tex_003A08[TEX_LEN(u64, gZelda2Tex_003A08_WIDTH, gZelda2Tex_003A08_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Tex_003A08.ci8.tlut_gZelda2_4TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003A48_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003A48_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003A48_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003A48_CITex.ci8.tlut_gZelda2_4TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003AC8_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003AC8_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003AC8_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003AC8_CITex.ci8.tlut_gZelda2_4TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003B48_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003B48_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003B48_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00003B48_CITex.ci8.tlut_gZelda2_4TLUT.inc.c"
+};
+
+u64 gZelda2EyeHalfTex[TEX_LEN(u64, gZelda2EyeHalfTex_WIDTH, gZelda2EyeHalfTex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2EyeHalfTex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2EyeShutTex[TEX_LEN(u64, gZelda2EyeShutTex_WIDTH, gZelda2EyeShutTex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2EyeShutTex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00004448_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00004448_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00004448_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00004448_CITex.ci8.tlut_gZelda2_4TLUT.inc.c"
+};
+
+u64 gZelda2Eye03Tex[TEX_LEN(u64, gZelda2Eye03Tex_WIDTH, gZelda2Eye03Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Eye03Tex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2Eye04Tex[TEX_LEN(u64, gZelda2Eye04Tex_WIDTH, gZelda2Eye04Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Eye04Tex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2Eye05Tex[TEX_LEN(u64, gZelda2Eye05Tex_WIDTH, gZelda2Eye05Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Eye05Tex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2Eye06Tex[TEX_LEN(u64, gZelda2Eye06Tex_WIDTH, gZelda2Eye06Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Eye06Tex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2MouthHappyTex[TEX_LEN(u64, gZelda2MouthHappyTex_WIDTH, gZelda2MouthHappyTex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2MouthHappyTex.ci8.tlut_gZelda2MouthTLUT.inc.c"
+};
+
+u64 gZelda2MouthOpenTex[TEX_LEN(u64, gZelda2MouthOpenTex_WIDTH, gZelda2MouthOpenTex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2MouthOpenTex.ci8.tlut_gZelda2MouthTLUT.inc.c"
+};
+
+u64 gZelda2Eye07Tex[TEX_LEN(u64, gZelda2Eye07Tex_WIDTH, gZelda2Eye07Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Eye07Tex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2Eye08Tex[TEX_LEN(u64, gZelda2Eye08Tex_WIDTH, gZelda2Eye08Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Eye08Tex.ci8.tlut_gZelda2EyesTLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00006548_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00006548_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00006548_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_00006548_CITex.ci8.tlut_gZelda2_4TLUT.inc.c"
+};
+
+Vtx gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_06006748_Vtx_fused_[] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL_06006748_Vtx_fused_.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL[729] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb_06007DC8_DL.inc.c"
+};
+
+u64 gZelda2_5TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_5TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2_6TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_6TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2_7TLUT[] = {
+#include "assets/objects/object_zl2/gZelda2_7TLUT.tlut.rgba16.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009738_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009738_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009738_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009738_CITex.ci8.tlut_gZelda2_6TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009938_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009938_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009938_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009938_CITex.ci8.tlut_gZelda2_5TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A38_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A38_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A38_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A38_CITex.ci8.tlut_gZelda2_5TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A78_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A78_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A78_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009A78_CITex.ci8.tlut_gZelda2_5TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009E78_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009E78_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009E78_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009E78_CITex.ci8.tlut_gZelda2_6TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009F78_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009F78_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009F78_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009F78_CITex.ci8.tlut_gZelda2_6TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009FF8_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009FF8_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009FF8_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_00009FF8_CITex.ci8.tlut_gZelda2_7TLUT.inc.c"
+};
+
+u64 gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_0000A0F8_CITex[TEX_LEN(u64, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_0000A0F8_CITex_WIDTH, gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_0000A0F8_CITex_HEIGHT, 8)] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_0000A0F8_CITex.ci8.tlut_gZelda2_7TLUT.inc.c"
+};
+
+Vtx gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_0600A4F8_Vtx_fused_[] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL_0600A4F8_Vtx_fused_.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL[166] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb_0600B068_DL.inc.c"
+};
+
+u64 gZelda2OcarinaTex[TEX_LEN(u64, gZelda2OcarinaTex_WIDTH, gZelda2OcarinaTex_HEIGHT, 16)] = {
+#include "assets/objects/object_zl2/gZelda2OcarinaTex.rgba16.inc.c"
+};
+
+Vtx gZelda2OcarinaDL_0600B998_Vtx[] = {
+#include "assets/objects/object_zl2/gZelda2OcarinaDL_0600B998_Vtx.inc.c"
+};
+
+Gfx gZelda2OcarinaDL[37] = {
+#include "assets/objects/object_zl2/gZelda2OcarinaDL.inc.c"
+};
+
+Vtx gZelda2Skel_06010D38_Limbs_06010CFC_StandardLimb_0600F228_DL_0600BC10_Vtx_fused_[] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CFC_StandardLimb_0600F228_DL_0600BC10_Vtx_fused_.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL[112] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb_0600E590_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb_0600E910_DL[41] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb_0600E910_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb_0600EA58_DL[97] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb_0600EA58_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CE4_StandardLimb_0600ED60_DL[112] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CE4_StandardLimb_0600ED60_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CF0_StandardLimb_0600F0E0_DL[41] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CF0_StandardLimb_0600F0E0_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CFC_StandardLimb_0600F228_DL[97] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CFC_StandardLimb_0600F228_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL[437] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb_0600F530_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL[194] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb_060102D8_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CB4_StandardLimb_060108E8_DL[39] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CB4_StandardLimb_060108E8_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CC0_StandardLimb_06010A20_DL[39] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CC0_StandardLimb_06010A20_DL.inc.c"
+};
+
+Gfx gZelda2Skel_06010D38_Limbs_06010CCC_StandardLimb_06010B58_DL[39] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CCC_StandardLimb_06010B58_DL.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010C90_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C90_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010C9C_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CA8_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CB4_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CB4_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CC0_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CC0_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CCC_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CCC_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CD8_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CE4_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CE4_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CF0_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CF0_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010CFC_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010CFC_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D08_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D14_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D20_StandardLimb.inc.c"
+};
+
+StandardLimb gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs_06010D2C_StandardLimb.inc.c"
+};
+
+void* gZelda2Skel_06010D38_Limbs[] = {
+#include "assets/objects/object_zl2/gZelda2Skel_06010D38_Limbs.inc.c"
+};
+
+FlexSkeletonHeader gZelda2Skel = {
+#include "assets/objects/object_zl2/gZelda2Skel.inc.c"
+};


### PR DESCRIPTION
Reduces the used object RAM by a little over 0.01 MB for the final Ganon boss by removing unused assets from three loaded objects during that scene.