### PR TITLE
Disable OS VI Dither Filter

### DIFF
--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -87,7 +87,7 @@ void Idle_ThreadEntry(void* arg) {
     osCreateViManager(OS_PRIORITY_VIMGR);
 
 #if OOT_VERSION >= PAL_1_0
-    gViConfigFeatures = OS_VI_GAMMA_OFF | OS_VI_DITHER_FILTER_ON;
+    gViConfigFeatures = OS_VI_GAMMA_OFF | OS_VI_DITHER_FILTER_OFF;
     gViConfigXScale = 1.0f;
     gViConfigYScale = 1.0f;
 #endif

--- a/src/boot/viconfig.c
+++ b/src/boot/viconfig.c
@@ -5,7 +5,7 @@
 s8 D_80009430 = 1;
 vu8 gViConfigBlack = true;
 u8 gViConfigAdditionalScanLines = 0;
-u32 gViConfigFeatures = OS_VI_DITHER_FILTER_ON | OS_VI_GAMMA_OFF;
+u32 gViConfigFeatures = OS_VI_DITHER_FILTER_OFF | OS_VI_GAMMA_OFF;
 f32 gViConfigXScale = 1.0;
 f32 gViConfigYScale = 1.0;
 

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -201,7 +201,7 @@ void Graph_Init(GraphicsContext* gfxCtx) {
     gfxCtx->viMode = NULL;
 
 #if OOT_VERSION < PAL_1_0
-    gfxCtx->viFeatures = 0;
+    gfxCtx->viFeatures = OS_VI_GAMMA_OFF | OS_VI_DITHER_FILTER_OFF;
 #else
     gfxCtx->viFeatures = gViConfigFeatures;
     gfxCtx->xScale = gViConfigXScale;


### PR DESCRIPTION
Disables the OS VI Dither Filter

Might be worth testing how much of a performance boost it gives, and how it visually compares. Mostly on console.