### PR TITLE
Math inlining

### DIFF
--- a/include/libc64/math64.h
+++ b/include/libc64/math64.h
@@ -7,27 +7,27 @@
  * @param angle radians
  * @return tan(angle)
  */
-static f32 Math_FTanF(f32 angle) {
+static inline f32 Math_FTanF(f32 angle) {
     return sinf(angle) / cosf(angle);
 }
 
-static f32 Math_FFloorF(f32 x) {
+static inline f32 Math_FFloorF(f32 x) {
     return floorf(x);
 }
 
-static f32 Math_FCeilF(f32 x) {
+static inline f32 Math_FCeilF(f32 x) {
     return ceilf(x);
 }
 
-static f32 Math_FRoundF(f32 x) {
+static inline f32 Math_FRoundF(f32 x) {
     return roundf(x);
 }
 
-static f32 Math_FTruncF(f32 x) {
+static inline f32 Math_FTruncF(f32 x) {
     return truncf(x);
 }
 
-static f32 Math_FNearbyIntF(f32 x) {
+static inline f32 Math_FNearbyIntF(f32 x) {
     return nearbyintf(x);
 }
 
@@ -38,7 +38,7 @@ f32 Math_FAsinF(f32 x);
 /**
  * @return arccos(x) in radians, in [0,pi] range
  */
-static f32 Math_FAcosF(f32 x) {
+static inline f32 Math_FAcosF(f32 x) {
     return M_PI / 2 - Math_FAsinF(x);
 }
 

--- a/include/ultra64.h
+++ b/include/ultra64.h
@@ -40,6 +40,12 @@
 #include "ultra64/ucode.h"
 #include "ultra64/version.h"
 
+#ifdef __sgi
+#ifndef inline
+#define inline __inline
+#endif
+#endif
+
 union uObjBg;
 
 void __osPiCreateAccessQueue(void);


### PR DESCRIPTION
Use inline for math functions. Used when GCC, otherwise use a no-op.