### PR TITLE
Raise sequences limit, set sceneFlags limit and fix chests

### DIFF
--- a/include/scene.h
+++ b/include/scene.h
@@ -319,7 +319,7 @@ typedef enum SceneID {
      & (ENTRANCE_INFO_START_TRANS_TYPE_MASK >> ENTRANCE_INFO_START_TRANS_TYPE_SHIFT))
 
 typedef struct EntranceInfo {
-    /* 0x00 */ s8  sceneId;
+    /* 0x00 */ u8  sceneId;
     /* 0x01 */ s8  spawn;
     /* 0x02 */ u16 field;
 } EntranceInfo; // size = 0x4

--- a/include/sequence.h
+++ b/include/sequence.h
@@ -10,8 +10,8 @@ typedef enum {
 #include "tables/sequence_table.h"
     NA_BGM_MAX,
 
-    NA_BGM_NO_MUSIC = 0x7F,
-    NA_BGM_NATURE_SFX_RAIN = 0x80,
+    NA_BGM_NO_MUSIC = 0xFFFD,
+    NA_BGM_NATURE_SFX_RAIN = 0xFFFE,
     NA_BGM_DISABLED = 0xFFFF
 } NA_BGM;
 #undef DEFINE_SEQUENCE

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2497,7 +2497,8 @@ void Actor_InitContext(PlayState* play, ActorContext* actorCtx, ActorEntry* play
     SavedSceneFlags* savedSceneFlags;
     s32 i;
 
-    savedSceneFlags = &gSaveContext.save.info.sceneFlags[play->sceneId];
+    if (play->sceneId < ARRAY_COUNT(gSaveContext.save.info.sceneFlags))
+        savedSceneFlags = &gSaveContext.save.info.sceneFlags[play->sceneId];
 
     bzero(actorCtx, sizeof(ActorContext));
 
@@ -2512,10 +2513,12 @@ void Actor_InitContext(PlayState* play, ActorContext* actorCtx, ActorEntry* play
         overlayEntry++;
     }
 
-    actorCtx->flags.chest = savedSceneFlags->chest;
-    actorCtx->flags.swch = savedSceneFlags->swch;
-    actorCtx->flags.clear = savedSceneFlags->clear;
-    actorCtx->flags.collect = savedSceneFlags->collect;
+    if (play->sceneId < ARRAY_COUNT(gSaveContext.save.info.sceneFlags)) {
+        actorCtx->flags.chest = savedSceneFlags->chest;
+        actorCtx->flags.swch = savedSceneFlags->swch;
+        actorCtx->flags.clear = savedSceneFlags->clear;
+        actorCtx->flags.collect = savedSceneFlags->collect;
+    }
 
     TitleCard_Init(play, &actorCtx->titleCtx);
 

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1993,8 +1993,12 @@ s16 func_800C09D8(PlayState* this, s16 camId, s16 uid) {
 }
 
 void Play_SaveSceneFlags(PlayState* this) {
-    SavedSceneFlags* savedSceneFlags = &gSaveContext.save.info.sceneFlags[this->sceneId];
+    SavedSceneFlags* savedSceneFlags;
 
+    if (this->sceneId >= ARRAY_COUNT(gSaveContext.save.info.sceneFlags))
+        return;
+
+    savedSceneFlags = &gSaveContext.save.info.sceneFlags[this->sceneId];
     savedSceneFlags->chest = this->actorCtx.flags.chest;
     savedSceneFlags->swch = this->actorCtx.flags.swch;
     savedSceneFlags->clear = this->actorCtx.flags.clear;

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -454,8 +454,8 @@ void EnBox_WaitOpen(EnBox* this, PlayState* play) {
         if (sp4C.z > -50.0f && sp4C.z < 0.0f && fabsf(sp4C.y) < 10.0f && fabsf(sp4C.x) < 20.0f &&
             Player_IsFacingActor(&this->dyna.actor, 0x3000, play)) {
             if (this->giItem > 0)
-                Actor_OfferGetItemNearby(&this->dyna.actor, play, -ENBOX_GET_GET_ITEM_ID(&this->dyna.actor));
-            else Actor_OfferGetItemNearby(&this->dyna.actor, play, -PARAMS_GET_U(this->dyna.actor.params, 5, 7));
+                Actor_OfferGetItemNearby(&this->dyna.actor, play, -this->giItem);
+            else Actor_OfferGetItemNearby(&this->dyna.actor, play, -ENBOX_GET_GET_ITEM_ID(&this->dyna.actor));
         }
         if (Flags_GetTreasure(play, ENBOX_GET_TREASURE_FLAG(&this->dyna.actor))) {
             EnBox_SetupAction(this, EnBox_Open);
@@ -626,7 +626,7 @@ bool EnBox_IsItem(s16 item) {
 void EnBox_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx, Gfx** gfx) {
     EnBox* this = (EnBox*)thisx;
     s32 pad;
-    u8 i = this->giItem > 0 ? this->giItem : PARAMS_GET_U(this->dyna.actor.params, 5, 7);
+    u8 i = this->giItem > 0 ? this->giItem : ENBOX_GET_TREASURE_FLAG(&this->dyna.actor);
     bool is_key = i == GI_SMALL_KEY;
     bool is_dungeon_item = i == GI_COMPASS || i == GI_DUNGEON_MAP;
     bool is_item = EnBox_IsItem(i);


### PR DESCRIPTION
Force a limit on loading and saving to scene flags, since the SRAM has only room for 124 scenes (max ID: 0x7B).

Simply don't load and save when the scene id is above that of the scene flags limit (which means those rooms will also be in their reset state).

We're not on our 124th scene just yet currently. So this PR isn't worth merging until we get there.

Secondly, raise the limit for music sequences by raising the ID values for NA_BGM_NO_MUSIC and NA_BGM_NATURE_SFX_RAIN so that newly added tracks don't overlap into the same IDs.