### PR TITLE
Isolate Double Defense upgrade

### DIFF
--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -854,7 +854,7 @@ void BgDyYoseizo_Give_Reward(BgDyYoseizo* this, PlayState* play) {
         this->item = NULL;
     }
 
-    if ((play->sceneId == SCENE_GREAT_FAIRYS_FOUNTAIN_MAGIC) && (play->csCtx.actorCues[0]->id == 18)) {
+    if ((play->sceneId == SCENE_GREAT_FAIRYS_FOUNTAIN_MAGIC) && (play->csCtx.actorCues[0]->id == 18) && this->fountainType == FAIRY_UPGRADE_DOUBLE_DEFENSE) {
         this->giveDefenseHearts = true;
     }
 


### PR DESCRIPTION
Fix an issue with the Woodfall Great Fairy upgrade (enhanced spin) who also gave Double Defense by accident.

Fixed by isolating the Double Defense upgrade to only the Double Defense Great Fairy type.