### PR TITLE
Fix shield durability meter & sword beam

### DIFF
--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -4284,9 +4284,9 @@ void Durability_DrawMeter(PlayState* play) {
     gDPSetEnvColor(OVERLAY_DISP++, 100, 50, 50, 255);
     meterX += 14;
 
-    OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(      OVERLAY_DISP, gMagicMeterEndTex, 8,  16, X_HIRES_MULTIPLY(meterX),                HIRES_MULTIPLY(meterY + 2), X_HIRES_MULTIPLY(8),        HIRES_MULTIPLY(16), 1 << 10, 1 << 10, sMagicBorderR, sMagicBorderG, sMagicBorderB, interfaceCtx->magicAlpha);
-    OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(      OVERLAY_DISP, gMagicMeterMidTex, 24, 16, X_HIRES_MULTIPLY(meterX + 8),            HIRES_MULTIPLY(meterY + 2), X_HIRES_MULTIPLY(capacity), HIRES_MULTIPLY(16), 1 << 10, 1 << 10, sMagicBorderR, sMagicBorderG, sMagicBorderB, interfaceCtx->magicAlpha);
-    OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadowOffset(OVERLAY_DISP, gMagicMeterEndTex, 8,  16, X_HIRES_MULTIPLY(meterX + capacity + 8), HIRES_MULTIPLY(meterY + 2), X_HIRES_MULTIPLY(8),        HIRES_MULTIPLY(16), 1 << 10, 1 << 10, sMagicBorderR, sMagicBorderG, sMagicBorderB, interfaceCtx->magicAlpha, 3, 0x100);
+    OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(      OVERLAY_DISP, gMagicMeterEndTex, 8,  16, X_HIRES_MULTIPLY(meterX),                HIRES_MULTIPLY(meterY + 2), X_HIRES_MULTIPLY(8),        HIRES_MULTIPLY(16), 1 << 10, 1 << 10, 255, 255, 255, interfaceCtx->magicAlpha);
+    OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(      OVERLAY_DISP, gMagicMeterMidTex, 24, 16, X_HIRES_MULTIPLY(meterX + 8),            HIRES_MULTIPLY(meterY + 2), X_HIRES_MULTIPLY(capacity), HIRES_MULTIPLY(16), 1 << 10, 1 << 10, 255, 255, 255, interfaceCtx->magicAlpha);
+    OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadowOffset(OVERLAY_DISP, gMagicMeterEndTex, 8,  16, X_HIRES_MULTIPLY(meterX + capacity + 8), HIRES_MULTIPLY(meterY + 2), X_HIRES_MULTIPLY(8),        HIRES_MULTIPLY(16), 1 << 10, 1 << 10, 255, 255, 255, interfaceCtx->magicAlpha, 3, 0x100);
 
     gDPPipeSync(OVERLAY_DISP++);
     gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, 0, 0, 0, PRIMITIVE, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, 0, 0, 0, PRIMITIVE);

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -129,7 +129,7 @@ void EnMThunder_Init(Actor* thisx, PlayState* play2) {
                 break;
         }
 
-        if (HAS_HEROS_SWORD && CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) == EQUIP_VALUE_SWORD_KOKIRI) {
+        if (HAS_HEROS_SWORD && CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) == EQUIP_VALUE_SWORD_KOKIRI && player->itemAction == PLAYER_IA_SWORD_KOKIRI) {
             this->unk_1C6 += ENMTHUNDER_SUBTYPE_SWORDBEAM_GREAT;
             func_80A9EFE0(this, EnMThunder_SwordBeam_Attack);
             this->unk_1C4 = 1;


### PR DESCRIPTION
Fixes two issues:
1. Shield durability meter display won't flash anymore when using magic, the border stays white
2. Sword beam can only be used if the Hero's Sword is used in addition to existing checks

Previously the sword beam could be used if only the Hero's Sword was equipped and obtained, which allowed other weapons through C such as the Great Fairy's Sword to also use sword beams so long the Hero's Sword was on the B button.