### PR TITLE
Nerf Purple Rupees for Peahat with Light Arrow

### DIFF
--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -139,6 +139,7 @@ static ColliderQuadInit sQuadInit = {
 
 typedef enum EnPeehatDamageReaction {
     /* 00 */ PEAHAT_DMG_REACT_ATTACK = 0,
+    /* 01 */ PEAHAT_DMG_REACT_LIGHT_ARROW,
     /* 06 */ PEAHAT_DMG_REACT_LIGHT_ICE_ARROW = 6,
     /* 12 */ PEAHAT_DMG_REACT_FIRE = 12,
     /* 13 */ PEAHAT_DMG_REACT_HOOKSHOT = 13,
@@ -160,7 +161,7 @@ static DamageTable sDamageTable = {
     /* Giant's Knife */ DMG_ENTRY(4, PEAHAT_DMG_REACT_ATTACK),
     /* Fire arrow    */ DMG_ENTRY(4, PEAHAT_DMG_REACT_FIRE),
     /* Ice arrow     */ DMG_ENTRY(2, PEAHAT_DMG_REACT_ATTACK),
-    /* Light arrow   */ DMG_ENTRY(2, PEAHAT_DMG_REACT_ATTACK),
+    /* Light arrow   */ DMG_ENTRY(2, PEAHAT_DMG_REACT_LIGHT_ARROW),
     /* Unk arrow 1   */ DMG_ENTRY(2, PEAHAT_DMG_REACT_ATTACK),
     /* Unk arrow 2   */ DMG_ENTRY(2, PEAHAT_DMG_REACT_ATTACK),
     /* Unk arrow 3   */ DMG_ENTRY(2, PEAHAT_DMG_REACT_ATTACK),
@@ -232,6 +233,7 @@ void EnPeehat_Init(Actor* thisx, PlayState* play) {
     this->actor.cullingVolumeDistance = 4000.0f;
     this->actor.cullingVolumeScale = 800.0f;
     this->actor.cullingVolumeDownward = 1800.0f;
+    this->hitByLightArrow = false;
     switch (this->actor.params) {
         case PEAHAT_TYPE_GROUNDED_LARVA:
             EnPeehat_Ground_SetStateGround(this);
@@ -310,8 +312,10 @@ void EnPeehat_HitWhenGrounded(EnPeehat* this, PlayState* play) {
         Vec3f itemDropPos = this->actor.world.pos;
 
         itemDropPos.y += 70.0f;
-        Item_DropCollectibleRandom(play, &this->actor, &itemDropPos, 0x40);
-        Item_DropCollectibleRandom(play, &this->actor, &itemDropPos, 0x40);
+        if (!this->hitByLightArrow) {
+            Item_DropCollectibleRandom(play, &this->actor, &itemDropPos, 0x40);
+            Item_DropCollectibleRandom(play, &this->actor, &itemDropPos, 0x40);
+        }
         Item_DropCollectibleRandom(play, &this->actor, &itemDropPos, 0x40);
         this->unk_2D4 = 240;
     } else {
@@ -896,8 +900,10 @@ void EnPeehat_StateExplode(EnPeehat* this, PlayState* play) {
     }
     this->animTimer--;
     if (this->animTimer == 0) {
-        Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0x40);
-        Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0x40);
+        if (!this->hitByLightArrow) {
+            Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0x40);
+            Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0x40);
+        }
         Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0x40);
         Actor_Kill(&this->actor);
     }
@@ -926,6 +932,8 @@ void EnPeehat_Adult_CollisionCheck(EnPeehat* this, PlayState* play) {
             Actor_ApplyDamage(&this->actor);
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
             Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_DAMAGE);
+            if (this->actor.colChkInfo.damageReaction == PEAHAT_DMG_REACT_LIGHT_ARROW)
+                this->hitByLightArrow = true;
         }
 
         if (this->actor.colChkInfo.damageReaction == PEAHAT_DMG_REACT_FIRE) {

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
@@ -43,6 +43,7 @@ typedef struct EnPeehat {
     /* 0x034C */ ColliderJntSph colliderJntSph;
     /* 0x036C */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x03AC */ ColliderQuad colliderQuad;
-} EnPeehat; // size = 0x042C
+    /* 0x042C */ bool hitByLightArrow;
+} EnPeehat; // size = 0x0430
 
 #endif


### PR DESCRIPTION
When killing enemies with Light Arrows, all item drops turn into Purple Rupees (if the enemy can be hit with it of course, and if no other exceptions exist).

The Peahat always drops 3 random items when killed (won't always be three drops cus since it's random it can be nothing too), but when killed with Light Arrrows it will always give 3 Purple Rupees. Items are no longer randomized when enemies are killed with Light Arrows and always result in Purple Rupees.

Long story short, three Purple Rupees is just too OP, especially since the Peahat isn't supposed to be killable with Light Arrows since in the vanilla game you don't encounter them as Adult Link anymore (who can only use the bow).

But you can kill Peahats with the Light Arrows in Child Quest, and the Peahats in the Forbidden Woods are slightly weaker at just 4 HP (so two Light Arrow shots), giving you 150 Rupees for every two Light Arrows you fire. It's a late game item yes, and it's fine to drop Purple Rupees, but three of them is too much especially for a combination not possible in the vanilla game.

The solution? Only drop a single item (that turns into a Purple Rupee) when the Peahat is killed by an Light Arrow attack (aka, reaches 0 health).