### PR TITLE
Another fixes roundup for Child Quest v6

### DIFF
--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -40,6 +40,11 @@ void Interface_Init(PlayState* play) {
     gItemIcons[ITEM_STRENGTH_GOLD_GAUNTLETS]   = IS_CHILD_QUEST_AS_CHILD ? gItemIconPowerBraceletsTex    : gItemIconGoldenGauntletsTex;
     gItemIcons[ITEM_BROKEN_GORONS_SWORD]       = IS_CHILD_QUEST          ? gItemIconGoldDustTex          : gItemIconBrokenGoronsSwordTex;
 
+    if (SHIELD_DURABILITY)
+        for (i=0; i<4; i++)
+            if (gSaveContext.save.info.shields[i].durability > Player_GetMaxShieldDurability(i+1))
+                gSaveContext.save.info.shields[i].durability = Player_GetMaxShieldDurability(i+1);
+
     if (gSaveContext.save.info.equips.buttonItems[0] == ITEM_SWORD_BIGGORON && !gSaveContext.save.info.playerData.swordHealth && LINK_IS_ADULT)
         gSaveContext.save.info.equips.buttonItems[0] = ITEM_GIANTS_KNIFE;
     else if (gSaveContext.save.info.equips.buttonItems[0] == ITEM_GIANTS_KNIFE && IS_CHILD_QUEST_AS_CHILD)

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1763,6 +1763,8 @@ void Play_GetScreenPos(PlayState* this, Vec3f* src, Vec3f* dest) {
     w = this->viewProjectionMtxF.ww + (this->viewProjectionMtxF.wx * src->x + this->viewProjectionMtxF.wy * src->y +
                                        this->viewProjectionMtxF.wz * src->z);
 
+    if (R_ENABLE_MIRROR == 1)
+        dest->x *= -1;
     dest->x = (SCREEN_WIDTH / 2) + ((dest->x / w) * (SCREEN_WIDTH / 2));
     dest->y = (SCREEN_HEIGHT / 2) - ((dest->y / w) * (SCREEN_HEIGHT / 2));
 }

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -2880,14 +2880,14 @@ void BossGanon_UpdateDamage(BossGanon* this, PlayState* play) {
                     }
                 }
 
-                if (this->actor.colChkInfo.health <= 0 && !this->swordPhase && hasSword) {
+                if ((s16)this->actor.colChkInfo.health <= 0 && !this->swordPhase && hasSword) {
                     BossGanon_SetupSwordPhaseCutscene(this, play);
                     Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DEAD);
                     Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DD_THUNDER);
                     Sfx_PlaySfxAtPos(&sZeroVec, NA_SE_EN_LAST_DAMAGE);
                     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 1);
                     this->screenFlashTimer = 4;
-                } else if (this->actor.colChkInfo.health <= 0) {
+                } else if ((s16)this->actor.colChkInfo.health <= 0) {
                     BossGanon_SetupDeathCutscene(this, play);
                     Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DEAD);
                     Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DD_THUNDER);

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -60,6 +60,9 @@ void EnWeatherTag_SetupAction(EnWeatherTag* this, EnWeatherTagActionFunc actionF
 void EnWeatherTag_Destroy(Actor* thisx, PlayState* play) {
     EnWeatherTag* this = (EnWeatherTag*)thisx;
 
+    if (this->killedOnInit)
+        return;
+
     if (PARAMS_GET_U(this->actor.params, 0, 4) == EN_WEATHER_TAG_TYPE_THUNDERSTORM_KAKARIKO) {
         play->envCtx.lightConfig = 4;        
         play->envCtx.changeSkyboxTimer = play->envCtx.changeDuration = 100;
@@ -90,6 +93,7 @@ void EnWeatherTag_Init(Actor* thisx, PlayState* play) {
     EnWeatherTag* this = (EnWeatherTag*)thisx;
 
     this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
+    this->killedOnInit = false;
 
     switch (PARAMS_GET_U(this->actor.params, 0, 4)) {
         case EN_WEATHER_TAG_TYPE_CLOUDY_MARKET:
@@ -104,6 +108,7 @@ void EnWeatherTag_Init(Actor* thisx, PlayState* play) {
                                       "☆☆☆☆☆ Cloudy (._.) Ah Melancholy ☆☆☆☆☆ \n") VT_RST);
             if (Flags_GetEventChkInf(EVENTCHKINF_EPONA_OBTAINED)) {
                 Actor_Kill(&this->actor);
+                this->killedOnInit = true;
             }
             EnWeatherTag_SetupAction(this, EnWeatherTag_DisabledCloudyLonLonRanch);
             break;
@@ -114,6 +119,7 @@ void EnWeatherTag_Init(Actor* thisx, PlayState* play) {
 
             if (GET_EVENTCHKINF(EVENTCHKINF_4A)) {
                 Actor_Kill(&this->actor);
+                this->killedOnInit = true;
             }
             EnWeatherTag_SetupAction(this, EnWeatherTag_DisabledCloudySnow);
             break;
@@ -124,6 +130,7 @@ void EnWeatherTag_Init(Actor* thisx, PlayState* play) {
 
             if (GET_EVENTCHKINF(EVENTCHKINF_4A)) {
                 Actor_Kill(&this->actor);
+                this->killedOnInit = true;
             }
             EnWeatherTag_SetupAction(this, EnWeatherTag_DisabledRainLakeHylia);
             break;
@@ -133,6 +140,7 @@ void EnWeatherTag_Init(Actor* thisx, PlayState* play) {
                        T("☆☆☆☆☆ くもり (._.) あーあ 憂鬱 ☆☆☆☆☆ \n", "☆☆☆☆☆ Cloudy (._.) Ah Melancholy ☆☆☆☆☆") VT_RST);
             if (GET_EVENTCHKINF(EVENTCHKINF_49)) {
                 Actor_Kill(&this->actor);
+                this->killedOnInit = true;
             }
             EnWeatherTag_SetupAction(this, EnWeatherTag_DisabledCloudyDeathMountain);
             break;
@@ -144,6 +152,7 @@ void EnWeatherTag_Init(Actor* thisx, PlayState* play) {
             if (!GET_EVENTCHKINF(EVENTCHKINF_48) || !GET_EVENTCHKINF(EVENTCHKINF_49) ||
                 !GET_EVENTCHKINF(EVENTCHKINF_4A) || CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
                 Actor_Kill(&this->actor);
+                this->killedOnInit = true;
             }
             EnWeatherTag_SetupAction(this, EnWeatherTag_DisabledCloudyRainThunderKakariko);
             break;

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.h
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.h
@@ -11,7 +11,8 @@ typedef void (*EnWeatherTagActionFunc)(struct EnWeatherTag*, struct PlayState*);
 typedef struct EnWeatherTag {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ EnWeatherTagActionFunc actionFunc;
-} EnWeatherTag; // size = 0x0154
+    /* 0x0154 */ bool killedOnInit;
+} EnWeatherTag; // size = 0x0158
 
 typedef enum EnWeatherTagType {
     /* 0x00 */ EN_WEATHER_TAG_TYPE_CLOUDY_MARKET,

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3084,13 +3084,14 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
     Interface_ChangeDpadSet(play);
     ArrowCycleHandle(this, play);
 
-    if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (featherGroundTimer <= 3)
-                featherGroundTimer++;
-    } else featherGroundTimer = 0;
-
-    if (featherGroundTimer >= 3)
-            this->featherUseCount = 0;
+    if (this->featherUseCount != 0) {
+        if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
+            if (featherGroundTimer <= 3)
+                    featherGroundTimer++;
+        } else featherGroundTimer = 0;
+        if (featherGroundTimer >= 3)
+                this->featherUseCount = 0;
+    }
 
     if (this->currentMask != PLAYER_MASK_NONE) {
         maskItemAction = this->currentMask - 1 + PLAYER_IA_MASK_KEATON;
@@ -3183,10 +3184,14 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 }
             }
         } else if (item != ITEM_ROCS_FEATHER && item != ITEM_GOLDEN_FEATHER) {
+            if (this->featherUseCount != 0)
+                if (item == ITEM_SLINGSHOT || item == ITEM_BOOMERANG || item == ITEM_HOOKSHOT || item == ITEM_LONGSHOT || item == ITEM_BOW || item == ITEM_BOW_FIRE || item == ITEM_BOW_ICE || item == ITEM_BOW_LIGHT)
+                    return;
             this->heldItemButton = i;
             Player_UseItem(play, this, item);
         } else if (this->featherUseCount < MAX_FEATHER_USES) {
-            if ( ( (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && this->speedXZ <= 0.2f && item == ITEM_ROCS_FEATHER && gSaveContext.save.info.energy >= 15) || (item == ITEM_GOLDEN_FEATHER && gSaveContext.save.info.energy >= 10)) {
+            u8 energyCost = (item == ITEM_ROCS_FEATHER ? 15 : 10) - (gSaveContext.save.info.obtainedItems.amuletOfEnergy * 5);
+            if ( (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (this->speedXZ <= 0.2f || item == ITEM_GOLDEN_FEATHER) && gSaveContext.save.info.energy >= energyCost) {
                 Vec3f effectsPos = this->actor.home.pos;
                 this->featherUseCount++;
                 func_80838940(this, &gPlayerAnim_link_normal_newroll_jump_20f, 7.15f, play, NA_SE_VO_LI_SWORD_N);
@@ -3198,7 +3203,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
                 EffectSsGSplash_Spawn(play, &effectsPos, NULL, NULL, 0, 150);
                 this->stateFlags2 &= ~(PLAYER_STATE2_19);
                 Player_PlaySfx(this, NA_SE_PL_SKIP);
-                gSaveContext.save.info.energy -= item == (ITEM_ROCS_FEATHER ? 15 : 10) - (gSaveContext.save.info.obtainedItems.amuletOfEnergy * 5);
+                gSaveContext.save.info.energy -= energyCost;
             }
         }
     }


### PR DESCRIPTION
Fixes several more issues not catched before during Child Quest v6:
- Energy meter display screen position being wrong in Mirror Mode in scenes with fixed camera
- Wrong animation for using a first person item such as the bow immediately after a feather jump
- Ganondorf phase 1 lacked signed 16-bit health comparison for being defeated, causing his health to overflow
- Roc's Feather and Golden Feather energy cost calculations were wrong, resulting in an energy cost of 0
- Reset shield durability back to max durability if it's above max durability upon scene load
- Don't reset weather effects when the weather actor is killed during initialization

When using Roc's Feather, first person items such as the bow can't be used anymore until Link landed on the ground again and feather use is reset again.

Roc's Feather should cost 15 energy and the Golden Feather 10 energy. Having the Amulet of Energy reduces the cost by another 5 energy. So the energy cost should vary between 15 and 5, and thus not 0.

https://github.com/user-attachments/assets/b249614f-2257-4d05-8257-797621d5cec7

https://github.com/user-attachments/assets/7b90cbd2-6332-4e3c-95b2-a26ea2c5d558