### PR TITLE
Smoother minimap transition & simplify SRAM header restore

### DIFF
--- a/include/regs.h
+++ b/include/regs.h
@@ -276,6 +276,7 @@ struct PlayState;
 #define R_BEATEN_RUSH_MODE                       dREG(90)
 #define R_SPECIAL_POWER_TIMER                    dREG(91)
 #define R_PERFECT_BLOCK_BOOST_TIMER              dREG(92)
+#define R_BLOCK_TRANSITION_MINIMAP               dREG(93)
 #define R_IS_YOUNG_LINK                          HREG(77)
 #define R_ENABLE_MIRROR                          HREG(78)
 #define R_QUEST_MODE                             HREG(79)

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -676,10 +676,10 @@ void Map_Update(PlayState* play) {
         switch (play->sceneId) {
             case SCENE_GORON_VILLAGE:
             case SCENE_GORON_SHRINE:
-                if (sMinimapResetTimer == ONE_SEC - 1)
+                if (sMinimapResetTimer == 1)
                     DMA_REQUEST_SYNC(interfaceCtx->mapSegment, sMinimapOffset, sMinimapSize, __FILE__, __LINE__);
-                else if (play->roomCtx.curRoom.num != sLastRoomNum) {
-                    sMinimapResetTimer = ONE_SEC;
+                else if (sMinimapResetTimer == 0 && play->roomCtx.curRoom.num != sLastRoomNum && !R_BLOCK_TRANSITION_MINIMAP) {
+                    sMinimapResetTimer = 2;
                     sLastRoomNum = play->roomCtx.curRoom.num;
                     Map_InitData(play, play->roomCtx.curRoom.num);
                     Map_RecalculateCompass();

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -476,7 +476,7 @@ void Play_Init(GameState* thisx) {
     this->unk_11E16 = 0xFF;
     this->bgCoverAlpha = 0;
     this->haltAllActors = false;
-    this->specialIconAlpha = this->specialIconShake = this->specialIconCount = this->specialIconLast = R_PERFECT_BLOCK_BOOST_TIMER = 0;
+    this->specialIconAlpha = this->specialIconShake = this->specialIconCount = this->specialIconLast = R_PERFECT_BLOCK_BOOST_TIMER = R_BLOCK_TRANSITION_MINIMAP = 0;
     this->specialIconUp = false;
 
     if (this->autosave != AUTOSAVE_ON && this->autosave != AUTOSAVE_OFF)

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -1179,7 +1179,6 @@ void Sram_WriteSramHeader(SramContext* sramCtx) {
 
 void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
     u16 i;
-    u8 sramHeaderSameCount = 0;
 
     PRINTF("sram_initialize( Game *game, Sram *sram )\n");
     SRAM_READ(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, SRAM_SIZE);
@@ -1200,12 +1199,10 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
         }
     }
 
-    for (i=0x10; i<0x20; i++) {
-        if (sramCtx->readBuff[i] == 255)
-            sramHeaderSameCount++;
-    }
-
-    if (sramHeaderSameCount >= 0x10) {
+    for (i=0x10; i<0x20; i++)
+        if (sramCtx->readBuff[i] != 255)
+            break;
+    if (i == 0x20) {
         for (i=0x10; i<0x20; i++)
             sramCtx->readBuff[i] = 0;
         Sram_WriteSramHeader(sramCtx);

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.c
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.c
@@ -200,6 +200,12 @@ void EnHoll_HorizontalVisibleNarrow(EnHoll* this, PlayState* play) {
     Actor_WorldToActorCoords(&this->actor, &relPlayerPos, &player->actor.world.pos);
     this->side = (relPlayerPos.z < 0.0f  && !isSceneChanger) ? 0 : 1;
     orthogonalDistToPlayer = fabsf(relPlayerPos.z);
+
+    if (orthogonalDistToPlayer <= 150.0f)
+        R_BLOCK_TRANSITION_MINIMAP = 1;
+    else if (R_BLOCK_TRANSITION_MINIMAP && orthogonalDistToPlayer > 150.0f && orthogonalDistToPlayer < 200.0f)
+        R_BLOCK_TRANSITION_MINIMAP = 0;
+
     if (relPlayerPos.y > ENHOLL_H_Y_MIN && relPlayerPos.y < ENHOLL_H_Y_MAX &&
         fabsf(relPlayerPos.x) < ENHOLL_H_HALFWIDTH_NARROW &&
         orthogonalDistToPlayer < sHorizontalVisibleNarrowTriggerDists[triggerDistsIndex][0]) {


### PR DESCRIPTION
Smoothens the minimap transition for overworld maps where used (when switching rooms in Goron Village and Goron Shrine)

- Delay reduced to 2 frames (frame 1: stop drawing, frame 2: refresh minimap, frame 3: draw again)
- Prevent refreshing the minimap when too close near a narrow black fade transition actor that changes rooms

Also simplify the SRAM header restore