### PR TITLE
Adjust sequences limit

### DIFF
--- a/include/sequence.h
+++ b/include/sequence.h
@@ -10,8 +10,8 @@ typedef enum {
 #include "tables/sequence_table.h"
     NA_BGM_MAX,
 
-    NA_BGM_NO_MUSIC = 0xFFFD,
-    NA_BGM_NATURE_SFX_RAIN = 0xFFFE,
+    NA_BGM_NO_MUSIC = 0xFD,
+    NA_BGM_NATURE_SFX_RAIN = 0xFE,
     NA_BGM_DISABLED = 0xFFFF
 } NA_BGM;
 #undef DEFINE_SEQUENCE


### PR DESCRIPTION
Follow-up to #240

Problem is that while sequences are 16-bit, they're stored as 8-bit in the SRAM. So the max limit would be 0xFC (253 different tracks, still more than plenty, and we still likely run out of ROM space before that) then.