### PR TITLE
Revert - Audio: Fix note values

### DIFF
--- a/assets/xml/audio/samplebanks/SampleBank_0.xml
+++ b/assets/xml/audio/samplebanks/SampleBank_0.xml
@@ -12,8 +12,8 @@
     <Sample Name="SAMPLE_0_9" FileName="Sample009" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_10" FileName="Sample010" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_11" FileName="Sample011" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_12" FileName="Sample012" SampleRate="16000" BaseNote="G3"/>
-    <Sample Name="SAMPLE_0_13" FileName="Sample013" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_12" FileName="Sample012" SampleRate="32000" BaseNote="F3"/>
+    <Sample Name="SAMPLE_0_13" FileName="Sample013" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_14" FileName="Sample014" SampleRate="24000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_15" FileName="Sample015" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_16" FileName="Sample016" SampleRate="22050" BaseNote="C4"/>
@@ -22,11 +22,11 @@
     <Sample Name="SAMPLE_0_19" FileName="Sample019" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_20" FileName="Sample020" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_21" FileName="Sample021" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_22" FileName="Sample022" SampleRate="16000" BaseNote="F3"/>
+    <Sample Name="SAMPLE_0_22" FileName="Sample022" SampleRate="16000" BaseNote="G4"/>
     <Sample Name="SAMPLE_0_23" FileName="Sample023" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_24" FileName="Sample024" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_25" FileName="Sample025" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_26" FileName="Sample026" SampleRate="16000" BaseNote="F5"/>
+    <Sample Name="SAMPLE_0_26" FileName="Sample026" SampleRate="8000" BaseNote="G3"/>
     <Sample Name="SAMPLE_0_27" FileName="Sample027" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_28" FileName="Sample028" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_29" FileName="Sample029" SampleRate="22050" BaseNote="C4"/>
@@ -41,7 +41,7 @@
     <Sample Name="SAMPLE_0_38" FileName="Sample038" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_39" FileName="Sample039" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_40" FileName="Sample040" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_41" FileName="Sample041" SampleRate="16000" BaseNote="E3"/>
+    <Sample Name="SAMPLE_0_41" FileName="Sample041" SampleRate="16000" BaseNote="AF4"/>
     <Sample Name="SAMPLE_0_42" FileName="Sample042" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_43" FileName="Sample043" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_44" FileName="Sample044" SampleRate="16000" BaseNote="C4"/>
@@ -64,34 +64,34 @@
     <Sample Name="SAMPLE_0_61" FileName="Sample061" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_62" FileName="Sample062" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_63" FileName="Sample063" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_64" FileName="Sample064" SampleRate="22050" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_64" FileName="Sample064" SampleRate="22050" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_65" FileName="Sample065" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_66" FileName="Sample066" SampleRate="22050" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_67" FileName="Sample067" SampleRate="16000" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_68" FileName="Sample068" SampleRate="22050" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_69" FileName="Sample069" SampleRate="45530" BaseNote="G6"/>
+    <Sample Name="SAMPLE_0_66" FileName="Sample066" SampleRate="22050" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_67" FileName="Sample067" SampleRate="16000" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_68" FileName="Sample068" SampleRate="22050" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_69" FileName="Sample069" SampleRate="45530" BaseNote="F1"/>
     <Sample Name="SAMPLE_0_70" FileName="Sample070" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_71" FileName="Sample071" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_71" FileName="Sample071" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_72" FileName="Sample072" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_73" FileName="Sample073" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_74" FileName="Sample074" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_75" FileName="Sample075" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_76" FileName="Sample076" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_76" FileName="Sample076" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_77" FileName="Sample077" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_78" FileName="Sample078" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_79" FileName="Sample079" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_80" FileName="Sample080" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_81" FileName="Sample081" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_82" FileName="Sample082" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_83" FileName="Sample083" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_83" FileName="Sample083" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_84" FileName="Sample084" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_85" FileName="Sample085" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_86" FileName="Sample086" SampleRate="24000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_87" FileName="Sample087" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_88" FileName="Sample088" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_89" FileName="Sample089" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_89" FileName="Sample089" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_90" FileName="Sample090" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_91" FileName="Sample091" SampleRate="32000" BaseNote="DF6"/>
+    <Sample Name="SAMPLE_0_91" FileName="Sample091" SampleRate="32000" BaseNote="B1"/>
     <Sample Name="SAMPLE_0_92" FileName="Sample092" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_93" FileName="Sample093" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_94" FileName="Sample094" SampleRate="16000" BaseNote="C4"/>
@@ -101,29 +101,29 @@
     <Sample Name="SAMPLE_0_98" FileName="Sample098" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_99" FileName="Sample099" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_100" FileName="Sample100" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_101" FileName="Sample101" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_101" FileName="Sample101" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_102" FileName="Sample102" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_103" FileName="Sample103" SampleRate="22050" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_104" FileName="Sample104" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_103" FileName="Sample103" SampleRate="22050" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_104" FileName="Sample104" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_105" FileName="Sample105" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_106" FileName="Sample106" SampleRate="8000" BaseNote="EF7"/>
-    <Sample Name="SAMPLE_0_107" FileName="Sample107" SampleRate="16000" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_108" FileName="Sample108" SampleRate="16000" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_109" FileName="Sample109" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_106" FileName="Sample106" SampleRate="8000" BaseNote="A0"/>
+    <Sample Name="SAMPLE_0_107" FileName="Sample107" SampleRate="16000" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_108" FileName="Sample108" SampleRate="16000" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_109" FileName="Sample109" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_110" FileName="Sample110" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_111" FileName="Sample111" SampleRate="22050" BaseNote="GF4"/>
+    <Sample Name="SAMPLE_0_111" FileName="Sample111" SampleRate="22050" BaseNote="GF3"/>
     <Sample Name="SAMPLE_0_112" FileName="Sample112" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_113" FileName="Sample113" SampleRate="22050" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_113" FileName="Sample113" SampleRate="22050" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_114" FileName="Sample114" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_115" FileName="Sample115" SampleRate="32000" BaseNote="AF4"/>
+    <Sample Name="SAMPLE_0_115" FileName="Sample115" SampleRate="32000" BaseNote="E3"/>
     <Sample Name="SAMPLE_0_116" FileName="Sample116" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_117" FileName="Sample117" SampleRate="24000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_118" FileName="Sample118" SampleRate="22050" BaseNote="AF4"/>
-    <Sample Name="SAMPLE_0_119" FileName="Sample119" SampleRate="8000" BaseNote="G3"/>
+    <Sample Name="SAMPLE_0_118" FileName="Sample118" SampleRate="22050" BaseNote="E3"/>
+    <Sample Name="SAMPLE_0_119" FileName="Sample119" SampleRate="32000" BaseNote="F2"/>
     <Sample Name="SAMPLE_0_120" FileName="Sample120" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_121" FileName="Sample121" SampleRate="32000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_121" FileName="Sample121" SampleRate="32000" BaseNote="D4"/>
     <Sample Name="SAMPLE_0_122" FileName="Sample122" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_123" FileName="Sample123" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_123" FileName="Sample123" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_124" FileName="Sample124" SampleRate="20000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_125" FileName="Sample125" SampleRate="20000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_126" FileName="Sample126" SampleRate="20000" BaseNote="C4"/>
@@ -235,10 +235,10 @@
     <Sample Name="SAMPLE_0_232" FileName="Sample232" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_233" FileName="Sample233" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_234" FileName="Sample234" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_235" FileName="Sample235" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_236" FileName="Sample236" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_237" FileName="Sample237" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_238" FileName="Sample238" SampleRate="16000" BaseNote="D4"/>
+    <Sample Name="SAMPLE_0_235" FileName="Sample235" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_236" FileName="Sample236" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_237" FileName="Sample237" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_238" FileName="Sample238" SampleRate="16000" BaseNote="BF3"/>
     <Sample Name="SAMPLE_0_239" FileName="Sample239" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_240" FileName="Sample240" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_241" FileName="Sample241" SampleRate="16000" BaseNote="C4"/>
@@ -257,11 +257,11 @@
     <Sample Name="SAMPLE_0_254" FileName="Sample254" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_255" FileName="Sample255" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_256" FileName="Sample256" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_257" FileName="Sample257" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_257" FileName="Sample257" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_258" FileName="Sample258" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_259" FileName="Sample259" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_260" FileName="Sample260" SampleRate="16000" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_261" FileName="Sample261" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_260" FileName="Sample260" SampleRate="16000" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_261" FileName="Sample261" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_262" FileName="Sample262" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_263" FileName="Sample263" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_264" FileName="Sample264" SampleRate="16000" BaseNote="C4"/>
@@ -275,7 +275,7 @@
     <Sample Name="SAMPLE_0_272" FileName="Sample272" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_273" FileName="Sample273" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_274" FileName="Sample274" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_275" FileName="Sample275" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_275" FileName="Sample275" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_276" FileName="Sample276" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_277" FileName="Sample277" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_278" FileName="Sample278" SampleRate="16000" BaseNote="C4"/>
@@ -284,7 +284,7 @@
     <Sample Name="SAMPLE_0_281" FileName="Sample281" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_282" FileName="Sample282" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_283" FileName="Sample283" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_284" FileName="Sample284" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_284" FileName="Sample284" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_285" FileName="Sample285" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_286" FileName="Sample286" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_287" FileName="Sample287" SampleRate="16000" BaseNote="C4"/>
@@ -297,14 +297,14 @@
     <Sample Name="SAMPLE_0_294" FileName="Sample294" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_295" FileName="Sample295" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_296" FileName="Sample296" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_297" FileName="Sample297" SampleRate="16000" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_298" FileName="Sample298" SampleRate="16000" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_299" FileName="Sample299" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_300" FileName="Sample300" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_301" FileName="Sample301" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_302" FileName="Sample302" SampleRate="16000" BaseNote="D4"/>
+    <Sample Name="SAMPLE_0_297" FileName="Sample297" SampleRate="16000" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_298" FileName="Sample298" SampleRate="16000" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_299" FileName="Sample299" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_300" FileName="Sample300" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_301" FileName="Sample301" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_302" FileName="Sample302" SampleRate="16000" BaseNote="BF3"/>
     <Sample Name="SAMPLE_0_303" FileName="Sample303" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_304" FileName="Sample304" SampleRate="16000" BaseNote="D4"/>
+    <Sample Name="SAMPLE_0_304" FileName="Sample304" SampleRate="16000" BaseNote="BF3"/>
     <Sample Name="SAMPLE_0_305" FileName="Sample305" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_306" FileName="Sample306" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_307" FileName="Sample307" SampleRate="16000" BaseNote="C4"/>
@@ -312,125 +312,125 @@
     <Sample Name="SAMPLE_0_309" FileName="Sample309" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_310" FileName="Sample310" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_311" FileName="Sample311" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_312" FileName="Sample312" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_312" FileName="Sample312" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_313" FileName="Sample313" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_314" FileName="Sample314" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_315" FileName="Sample315" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_316" FileName="Sample316" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_317" FileName="Sample317" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_318" FileName="Sample318" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_319" FileName="Sample319" SampleRate="16000" BaseNote="E4"/>
+    <Sample Name="SAMPLE_0_314" FileName="Sample314" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_315" FileName="Sample315" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_316" FileName="Sample316" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_317" FileName="Sample317" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_318" FileName="Sample318" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_319" FileName="Sample319" SampleRate="16000" BaseNote="AF3"/>
     <Sample Name="SAMPLE_0_320" FileName="Sample320" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_321" FileName="Sample321" SampleRate="16000" BaseNote="C8"/>
-    <Sample Name="SAMPLE_0_322" FileName="Sample322" SampleRate="16000" BaseNote="D4"/>
+    <Sample Name="SAMPLE_0_321" FileName="Sample321" SampleRate="16000" BaseNote="C0"/>
+    <Sample Name="SAMPLE_0_322" FileName="Sample322" SampleRate="16000" BaseNote="BF3"/>
     <Sample Name="SAMPLE_0_323" FileName="Sample323" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_324" FileName="Sample324" SampleRate="16000" BaseNote="E4"/>
-    <Sample Name="SAMPLE_0_325" FileName="Sample325" SampleRate="16000" BaseNote="E4"/>
-    <Sample Name="SAMPLE_0_326" FileName="Sample326" SampleRate="22050" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_327" FileName="Sample327" SampleRate="16000" BaseNote="E4"/>
-    <Sample Name="SAMPLE_0_328" FileName="Sample328" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_329" FileName="Sample329" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_330" FileName="Sample330" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_331" FileName="Sample331" SampleRate="16000" BaseNote="D4"/>
+    <Sample Name="SAMPLE_0_324" FileName="Sample324" SampleRate="16000" BaseNote="AF3"/>
+    <Sample Name="SAMPLE_0_325" FileName="Sample325" SampleRate="16000" BaseNote="AF3"/>
+    <Sample Name="SAMPLE_0_326" FileName="Sample326" SampleRate="22050" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_327" FileName="Sample327" SampleRate="16000" BaseNote="AF3"/>
+    <Sample Name="SAMPLE_0_328" FileName="Sample328" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_329" FileName="Sample329" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_330" FileName="Sample330" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_331" FileName="Sample331" SampleRate="16000" BaseNote="BF3"/>
     <Sample Name="SAMPLE_0_332" FileName="Sample332" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_333" FileName="Sample333" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_334" FileName="Sample334" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_335" FileName="Sample335" SampleRate="16000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_336" FileName="Sample336" SampleRate="16000" BaseNote="E4"/>
-    <Sample Name="SAMPLE_0_337" FileName="Sample337" SampleRate="16000" BaseNote="E4"/>
-    <Sample Name="SAMPLE_0_338" FileName="Sample338" SampleRate="16000" BaseNote="D4"/>
+    <Sample Name="SAMPLE_0_334" FileName="Sample334" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_335" FileName="Sample335" SampleRate="16000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_336" FileName="Sample336" SampleRate="16000" BaseNote="AF3"/>
+    <Sample Name="SAMPLE_0_337" FileName="Sample337" SampleRate="16000" BaseNote="AF3"/>
+    <Sample Name="SAMPLE_0_338" FileName="Sample338" SampleRate="16000" BaseNote="BF3"/>
     <Sample Name="SAMPLE_0_339" FileName="Sample339" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_340" FileName="Sample340" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_341" FileName="Sample341" SampleRate="16000" BaseNote="E4"/>
-    <Sample Name="SAMPLE_0_342" FileName="Sample342" SampleRate="16000" BaseNote="F4"/>
+    <Sample Name="SAMPLE_0_341" FileName="Sample341" SampleRate="16000" BaseNote="AF3"/>
+    <Sample Name="SAMPLE_0_342" FileName="Sample342" SampleRate="16000" BaseNote="G3"/>
     <Sample Name="SAMPLE_0_343" FileName="Sample343" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_344" FileName="Sample344" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_345" FileName="Sample345" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_346" FileName="Sample346" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_347" FileName="Sample347" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_348" FileName="Sample348" SampleRate="16000" BaseNote="C8"/>
+    <Sample Name="SAMPLE_0_348" FileName="Sample348" SampleRate="16000" BaseNote="C0"/>
     <Sample Name="SAMPLE_0_349" FileName="Sample349" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_350" FileName="Sample350" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_351" FileName="Sample351" SampleRate="32000" BaseNote="F3"/>
-    <Sample Name="SAMPLE_0_352" FileName="Sample352" SampleRate="32000" BaseNote="C6"/>
-    <Sample Name="SAMPLE_0_353" FileName="Sample353" SampleRate="22050" BaseNote="GF3"/>
+    <Sample Name="SAMPLE_0_351" FileName="Sample351" SampleRate="32000" BaseNote="G4"/>
+    <Sample Name="SAMPLE_0_352" FileName="Sample352" SampleRate="32000" BaseNote="C2"/>
+    <Sample Name="SAMPLE_0_353" FileName="Sample353" SampleRate="22050" BaseNote="GF4"/>
     <Sample Name="SAMPLE_0_354" FileName="Sample354" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_355" FileName="Sample355" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_356" FileName="Sample356" SampleRate="22050" BaseNote="EF2"/>
+    <Sample Name="SAMPLE_0_356" FileName="Sample356" SampleRate="22050" BaseNote="A5"/>
     <Sample Name="SAMPLE_0_357" FileName="Sample357" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_358" FileName="Sample358" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_359" FileName="Sample359" SampleRate="22050" BaseNote="F4"/>
-    <Sample Name="SAMPLE_0_360" FileName="Sample360" SampleRate="22050" BaseNote="B4"/>
+    <Sample Name="SAMPLE_0_359" FileName="Sample359" SampleRate="22050" BaseNote="G3"/>
+    <Sample Name="SAMPLE_0_360" FileName="Sample360" SampleRate="22050" BaseNote="DF3"/>
     <Sample Name="SAMPLE_0_361" FileName="Sample361" SampleRate="24000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_362" FileName="Sample362" SampleRate="32000" BaseNote="B4"/>
+    <Sample Name="SAMPLE_0_362" FileName="Sample362" SampleRate="32000" BaseNote="DF3"/>
     <Sample Name="SAMPLE_0_363" FileName="Sample363" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_364" FileName="Sample364" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_365" FileName="Sample365" SampleRate="16000" BaseNote="G3"/>
-    <Sample Name="SAMPLE_0_366" FileName="Sample366" SampleRate="32000" BaseNote="E2"/>
+    <Sample Name="SAMPLE_0_365" FileName="Sample365" SampleRate="32000" BaseNote="F3"/>
+    <Sample Name="SAMPLE_0_366" FileName="Sample366" SampleRate="32000" BaseNote="AF5"/>
     <Sample Name="SAMPLE_0_367" FileName="Sample367" SampleRate="22000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_368" FileName="Sample368" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_369" FileName="Sample369" SampleRate="32000" BaseNote="B3"/>
+    <Sample Name="SAMPLE_0_369" FileName="Sample369" SampleRate="32000" BaseNote="D4"/>
     <Sample Name="SAMPLE_0_370" FileName="Sample370" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_371" FileName="Sample371" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_372" FileName="Sample372" SampleRate="32000" BaseNote="C2"/>
-    <Sample Name="SAMPLE_0_373" FileName="Sample373" SampleRate="32000" BaseNote="AF3"/>
-    <Sample Name="SAMPLE_0_374" FileName="Sample374" SampleRate="32000" BaseNote="AF4"/>
-    <Sample Name="SAMPLE_0_375" FileName="Sample375" SampleRate="32000" BaseNote="AF4"/>
-    <Sample Name="SAMPLE_0_376" FileName="Sample376" SampleRate="32000" BaseNote="AF3"/>
-    <Sample Name="SAMPLE_0_377" FileName="Sample377" SampleRate="32000" BaseNote="EF5"/>
+    <Sample Name="SAMPLE_0_372" FileName="Sample372" SampleRate="32000" BaseNote="C6"/>
+    <Sample Name="SAMPLE_0_373" FileName="Sample373" SampleRate="32000" BaseNote="E4"/>
+    <Sample Name="SAMPLE_0_374" FileName="Sample374" SampleRate="32000" BaseNote="E3"/>
+    <Sample Name="SAMPLE_0_375" FileName="Sample375" SampleRate="32000" BaseNote="E3"/>
+    <Sample Name="SAMPLE_0_376" FileName="Sample376" SampleRate="32000" BaseNote="E4"/>
+    <Sample Name="SAMPLE_0_377" FileName="Sample377" SampleRate="32000" BaseNote="A2"/>
     <Sample Name="SAMPLE_0_378" FileName="Sample378" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_379" FileName="Sample379" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_380" FileName="Sample380" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_381" FileName="Sample381" SampleRate="32000" BaseNote="E5"/>
-    <Sample Name="SAMPLE_0_382" FileName="Sample382" SampleRate="32000" BaseNote="A2"/>
-    <Sample Name="SAMPLE_0_383" FileName="Sample383" SampleRate="32000" BaseNote="B2"/>
-    <Sample Name="SAMPLE_0_384" FileName="Sample384" SampleRate="32000" BaseNote="BF4"/>
+    <Sample Name="SAMPLE_0_381" FileName="Sample381" SampleRate="32000" BaseNote="AF2"/>
+    <Sample Name="SAMPLE_0_382" FileName="Sample382" SampleRate="32000" BaseNote="EF5"/>
+    <Sample Name="SAMPLE_0_383" FileName="Sample383" SampleRate="32000" BaseNote="DF5"/>
+    <Sample Name="SAMPLE_0_384" FileName="Sample384" SampleRate="32000" BaseNote="D3"/>
     <Sample Name="SAMPLE_0_385" FileName="Sample385" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_386" FileName="Sample386" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_387" FileName="Sample387" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_388" FileName="Sample388" SampleRate="24000" BaseNote="E2"/>
+    <Sample Name="SAMPLE_0_388" FileName="Sample388" SampleRate="24000" BaseNote="AF5"/>
     <Sample Name="SAMPLE_0_389" FileName="Sample389" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_390" FileName="Sample390" SampleRate="32000" BaseNote="C4" VersionInclude="ntsc-1.0,ntsc-1.1"/>
     <Sample Name="SAMPLE_0_391" FileName="Sample391" SampleRate="16000" BaseNote="C4" VersionInclude="ntsc-1.0,ntsc-1.1"/>
-    <Sample Name="SAMPLE_0_392" FileName="Sample392" SampleRate="16000" BaseNote="C6" VersionInclude="ntsc-1.0,ntsc-1.1"/>
-    <Sample Name="SAMPLE_0_393" FileName="Sample393" SampleRate="22050" BaseNote="EF4"/>
+    <Sample Name="SAMPLE_0_392" FileName="Sample392" SampleRate="16000" BaseNote="C2" VersionInclude="ntsc-1.0,ntsc-1.1"/>
+    <Sample Name="SAMPLE_0_393" FileName="Sample393" SampleRate="22050" BaseNote="A3"/>
     <Sample Name="SAMPLE_0_394" FileName="Sample394" SampleRate="22050" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_395" FileName="Sample395" SampleRate="27777" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_396" FileName="Sample396" SampleRate="32000" BaseNote="C5"/>
+    <Sample Name="SAMPLE_0_396" FileName="Sample396" SampleRate="32000" BaseNote="D3"/>
     <Sample Name="SAMPLE_0_397" FileName="Sample397" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_398" FileName="Sample398" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_399" FileName="Sample399" SampleRate="32000" BaseNote="G3"/>
-    <Sample Name="SAMPLE_0_400" FileName="Sample400" SampleRate="16000" BaseNote="D3"/>
-    <Sample Name="SAMPLE_0_401" FileName="Sample401" SampleRate="32000" BaseNote="D5"/>
-    <Sample Name="SAMPLE_0_402" FileName="Sample402" SampleRate="24000" BaseNote="BF3"/>
-    <Sample Name="SAMPLE_0_403" FileName="Sample403" SampleRate="32000" BaseNote="D3"/>
-    <Sample Name="SAMPLE_0_404" FileName="Sample404" SampleRate="16000" BaseNote="D3"/>
-    <Sample Name="SAMPLE_0_405" FileName="Sample405" SampleRate="32000" BaseNote="C2"/>
-    <Sample Name="SAMPLE_0_406" FileName="Sample406" SampleRate="32000" BaseNote="F2"/>
-    <Sample Name="SAMPLE_0_407" FileName="Sample407" SampleRate="24000" BaseNote="GF2"/>
+    <Sample Name="SAMPLE_0_399" FileName="Sample399" SampleRate="32000" BaseNote="F4"/>
+    <Sample Name="SAMPLE_0_400" FileName="Sample400" SampleRate="32000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_401" FileName="Sample401" SampleRate="32000" BaseNote="BF2"/>
+    <Sample Name="SAMPLE_0_402" FileName="Sample402" SampleRate="48000" BaseNote="D3"/>
+    <Sample Name="SAMPLE_0_403" FileName="Sample403" SampleRate="32000" BaseNote="BF4"/>
+    <Sample Name="SAMPLE_0_404" FileName="Sample404" SampleRate="32000" BaseNote="BF3"/>
+    <Sample Name="SAMPLE_0_405" FileName="Sample405" SampleRate="32000" BaseNote="C6"/>
+    <Sample Name="SAMPLE_0_406" FileName="Sample406" SampleRate="32000" BaseNote="G5"/>
+    <Sample Name="SAMPLE_0_407" FileName="Sample407" SampleRate="24000" BaseNote="GF5"/>
     <Sample Name="SAMPLE_0_408" FileName="Sample408" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_409" FileName="Sample409" SampleRate="24000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_410" FileName="Sample410" SampleRate="16000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_411" FileName="Sample411" SampleRate="32000" BaseNote="B3"/>
+    <Sample Name="SAMPLE_0_411" FileName="Sample411" SampleRate="32000" BaseNote="DF4"/>
     <Sample Name="SAMPLE_0_412" FileName="Sample412" SampleRate="24000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_413" FileName="Sample413" SampleRate="32000" BaseNote="E2"/>
-    <Sample Name="SAMPLE_0_414" FileName="Sample414" SampleRate="32000" BaseNote="AF3"/>
-    <Sample Name="SAMPLE_0_415" FileName="Sample415" SampleRate="32000" BaseNote="AF4"/>
+    <Sample Name="SAMPLE_0_413" FileName="Sample413" SampleRate="32000" BaseNote="AF5"/>
+    <Sample Name="SAMPLE_0_414" FileName="Sample414" SampleRate="32000" BaseNote="E4"/>
+    <Sample Name="SAMPLE_0_415" FileName="Sample415" SampleRate="32000" BaseNote="E3"/>
     <Sample Name="SAMPLE_0_416" FileName="Sample416" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_0_417" FileName="Sample417" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_418" FileName="Sample418" SampleRate="22050" BaseNote="C2"/>
+    <Sample Name="SAMPLE_0_418" FileName="Sample418" SampleRate="22050" BaseNote="F6"/>
     <Sample Name="SAMPLE_0_419" FileName="Sample419" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_420" FileName="Sample420" SampleRate="32000" BaseNote="EF6"/>
-    <Sample Name="SAMPLE_0_421" FileName="Sample421" SampleRate="24000" BaseNote="E2"/>
-    <Sample Name="SAMPLE_0_422" FileName="Sample422" SampleRate="24000" BaseNote="G3"/>
-    <Sample Name="SAMPLE_0_423" FileName="Sample423" SampleRate="24000" BaseNote="D4"/>
-    <Sample Name="SAMPLE_0_424" FileName="Sample424" SampleRate="32000" BaseNote="A4"/>
+    <Sample Name="SAMPLE_0_420" FileName="Sample420" SampleRate="32000" BaseNote="A1"/>
+    <Sample Name="SAMPLE_0_421" FileName="Sample421" SampleRate="24000" BaseNote="AF5"/>
+    <Sample Name="SAMPLE_0_422" FileName="Sample422" SampleRate="24000" BaseNote="F4"/>
+    <Sample Name="SAMPLE_0_423" FileName="Sample423" SampleRate="24000" BaseNote="BF2"/>
+    <Sample Name="SAMPLE_0_424" FileName="Sample424" SampleRate="32000" BaseNote="EF3"/>
     <Sample Name="SAMPLE_0_425" FileName="Sample425" SampleRate="22050" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_426" FileName="Sample426" SampleRate="16000" BaseNote="B1"/>
-    <Sample Name="SAMPLE_0_427" FileName="Sample427" SampleRate="22050" BaseNote="DF2"/>
-    <Sample Name="SAMPLE_0_428" FileName="Sample428" SampleRate="32000" BaseNote="D3"/>
-    <Sample Name="SAMPLE_0_429" FileName="Sample429" SampleRate="32000" BaseNote="A3"/>
-    <Sample Name="SAMPLE_0_430" FileName="Sample430" SampleRate="16000" BaseNote="C6" VersionExclude="ntsc-1.0,ntsc-1.1"/>
+    <Sample Name="SAMPLE_0_426" FileName="Sample426" SampleRate="16000" BaseNote="DF6"/>
+    <Sample Name="SAMPLE_0_427" FileName="Sample427" SampleRate="22050" BaseNote="B5"/>
+    <Sample Name="SAMPLE_0_428" FileName="Sample428" SampleRate="32000" BaseNote="BF4"/>
+    <Sample Name="SAMPLE_0_429" FileName="Sample429" SampleRate="32000" BaseNote="EF4"/>
+    <Sample Name="SAMPLE_0_430" FileName="Sample430" SampleRate="16000" BaseNote="C2" VersionExclude="ntsc-1.0,ntsc-1.1"/>
     <Sample Name="SAMPLE_0_431" FileName="Sample431" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_0_432" FileName="Sample432" SampleRate="32000" BaseNote="D5"/>
+    <Sample Name="SAMPLE_0_432" FileName="Sample432" SampleRate="32000" BaseNote="BF2"/>
 </SampleBank>

--- a/assets/xml/audio/samplebanks/SampleBank_2.xml
+++ b/assets/xml/audio/samplebanks/SampleBank_2.xml
@@ -1,4 +1,4 @@
 <!-- This file is only for extraction of vanilla data. For other purposes see assets/audio/samplebanks/ -->
 <SampleBank Name="SampleBank_2" Index="2">
-    <Sample Name="SAMPLE_2_0" FileName="Sample0" SampleRate="32000" BaseNote="G3"/>
+    <Sample Name="SAMPLE_2_0" FileName="Sample0" SampleRate="32000" BaseNote="F4"/>
 </SampleBank>

--- a/assets/xml/audio/samplebanks/SampleBank_4.xml
+++ b/assets/xml/audio/samplebanks/SampleBank_4.xml
@@ -1,8 +1,8 @@
 <!-- This file is only for extraction of vanilla data. For other purposes see assets/audio/samplebanks/ -->
 <SampleBank Name="SampleBank_4" Index="4">
     <Sample Name="SAMPLE_4_0" FileName="Sample0" SampleRate="24000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_4_1" FileName="Sample1" SampleRate="32000" BaseNote="E2"/>
-    <Sample Name="SAMPLE_4_2" FileName="Sample2" SampleRate="32000" BaseNote="AF3"/>
-    <Sample Name="SAMPLE_4_3" FileName="Sample3" SampleRate="32000" BaseNote="AF4"/>
-    <Sample Name="SAMPLE_4_4" FileName="Sample4" SampleRate="32000" BaseNote="B3"/>
+    <Sample Name="SAMPLE_4_1" FileName="Sample1" SampleRate="32000" BaseNote="AF5"/>
+    <Sample Name="SAMPLE_4_2" FileName="Sample2" SampleRate="32000" BaseNote="E4"/>
+    <Sample Name="SAMPLE_4_3" FileName="Sample3" SampleRate="32000" BaseNote="E3"/>
+    <Sample Name="SAMPLE_4_4" FileName="Sample4" SampleRate="32000" BaseNote="DF4"/>
 </SampleBank>

--- a/assets/xml/audio/samplebanks/SampleBank_5.xml
+++ b/assets/xml/audio/samplebanks/SampleBank_5.xml
@@ -2,8 +2,8 @@
 <SampleBank Name="SampleBank_5" Index="5">
     <Sample Name="SAMPLE_5_0" FileName="Sample0" SampleRate="16000" BaseNote="C4"/>
     <Sample Name="SAMPLE_5_1" FileName="Sample1" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_5_2" FileName="Sample2" SampleRate="22050" BaseNote="D3"/>
-    <Sample Name="SAMPLE_5_3" FileName="Sample3" SampleRate="16000" BaseNote="B1"/>
-    <Sample Name="SAMPLE_5_4" FileName="Sample4" SampleRate="22050" BaseNote="DF2"/>
-    <Sample Name="SAMPLE_5_5" FileName="Sample5" SampleRate="22050" BaseNote="EF4"/>
+    <Sample Name="SAMPLE_5_2" FileName="Sample2" SampleRate="22050" BaseNote="BF4"/>
+    <Sample Name="SAMPLE_5_3" FileName="Sample3" SampleRate="16000" BaseNote="DF6"/>
+    <Sample Name="SAMPLE_5_4" FileName="Sample4" SampleRate="22050" BaseNote="B5"/>
+    <Sample Name="SAMPLE_5_5" FileName="Sample5" SampleRate="22050" BaseNote="A3"/>
 </SampleBank>

--- a/assets/xml/audio/samplebanks/SampleBank_6.xml
+++ b/assets/xml/audio/samplebanks/SampleBank_6.xml
@@ -1,9 +1,9 @@
 <!-- This file is only for extraction of vanilla data. For other purposes see assets/audio/samplebanks/ -->
 <SampleBank Name="SampleBank_6" Index="6">
     <Sample Name="SAMPLE_6_0" FileName="Sample0" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_6_1" FileName="Sample1" SampleRate="32000" BaseNote="D5"/>
+    <Sample Name="SAMPLE_6_1" FileName="Sample1" SampleRate="32000" BaseNote="BF2"/>
     <Sample Name="SAMPLE_6_2" FileName="Sample2" SampleRate="32000" BaseNote="C4"/>
-    <Sample Name="SAMPLE_6_3" FileName="Sample3" SampleRate="22050" BaseNote="D3"/>
+    <Sample Name="SAMPLE_6_3" FileName="Sample3" SampleRate="22050" BaseNote="BF4"/>
     <Sample Name="SAMPLE_6_4" FileName="Sample4" SampleRate="32000" BaseNote="C4"/>
     <Sample Name="SAMPLE_6_5" FileName="Sample5" SampleRate="24000" BaseNote="C4"/>
     <Sample Name="SAMPLE_6_6" FileName="Sample6" SampleRate="24000" BaseNote="C4"/>

--- a/tools/audio/extraction/audiobank_file.py
+++ b/tools/audio/extraction/audiobank_file.py
@@ -129,9 +129,9 @@ class DrumGroup:
 
             notes.append(note)
 
-        # Drum frequencies should increase monotonically in a drum group
-        # Increasing frequencies correspond to decreasing note values
-        assert all(v == (notes[0] - i) % 128 for i,v in enumerate(notes))
+        # Note values should increase monotonically in a drum group
+        note_indices = [pitch_names.index(note) + 21 for note in notes]
+        assert all(v == note_indices[0] + i for i,v in enumerate(note_indices))
 
         # Assign final rate and note.
         # Use first note in the group as the basenote for the whole group, the rest will be filled in during build.
@@ -167,7 +167,7 @@ class DrumGroup:
         if self.needs_rate_override:
             attributes["SampleRate"] = self.sample_rate
         if self.needs_note_override:
-            attributes["BaseNote"] = pitch_names[self.base_note]
+            attributes["BaseNote"] = self.base_note
 
         xml.write_element("Drum", attributes)
 

--- a/tools/audio/extraction/audiobank_structs.py
+++ b/tools/audio/extraction/audiobank_structs.py
@@ -64,7 +64,7 @@ class SoundFontSample: # SampleHeader ?
         if rate_override is not None:
             attrs["SampleRate"] = rate_override
         if note_override is not None:
-            attrs["BaseNote"] = pitch_names[note_override]
+            attrs["BaseNote"] = note_overrid
         if self.medium != 0:
             attrs["IsDD"] = "true"
         if self.cached:
@@ -235,7 +235,7 @@ class SoundFontSound:
             if self.needs_rate_override:
                 attrs["SampleRate"] = self.sample_rate
             if self.needs_note_override:
-                attrs["BaseNote"] = pitch_names[self.base_note]
+                attrs["BaseNote"] = self.base_note
 
             xml.write_element("Effect", attrs)
 
@@ -383,7 +383,7 @@ class Instrument:
         if self.needs_rate_override[1]:
             attributes["SampleRate"] = self.sample_rate[1]
         if self.needs_note_override[1]:
-            attributes["BaseNote"] = pitch_names[self.base_note[1]]
+            attributes["BaseNote"] = self.base_note[1]
 
         if self.normal_range_lo != 0:
             attributes["RangeLo"] = pitch_names[self.normal_range_lo]
@@ -392,7 +392,7 @@ class Instrument:
             if self.needs_rate_override[0]:
                 attributes["SampleRateLo"] = self.sample_rate[0]
             if self.needs_note_override[0]:
-                attributes["BaseNoteLo"] = pitch_names[self.base_note[0]]
+                attributes["BaseNoteLo"] = self.base_note[0]
 
         if self.normal_range_hi != 127:
             attributes["RangeHi"] = pitch_names[self.normal_range_hi]
@@ -401,6 +401,6 @@ class Instrument:
             if self.needs_rate_override[2]:
                 attributes["SampleRateHi"] = self.sample_rate[2]
             if self.needs_note_override[2]:
-                attributes["BaseNoteHi"] = pitch_names[self.base_note[2]]
+                attributes["BaseNoteHi"] = self.base_note[2]
 
         xml.write_element("Instrument" if not self.unused else "InstrumentUnused", attributes)

--- a/tools/audio/extraction/audiotable.py
+++ b/tools/audio/extraction/audiotable.py
@@ -11,7 +11,7 @@ from .audio_tables import AudioCodeTableEntry
 from .audiobank_structs import AudioSampleCodec, SoundFontSample, AdpcmBook, AdpcmLoop
 from .extraction_xml import SampleBankExtractionDescription
 from .tuning import pitch_names, note_z64_to_midi, recalc_tuning, rate_from_tuning, rank_rates_notes, BAD_FLOATS
-from .util import align, XMLWriter, f32_to_u32
+from .util import align, error, XMLWriter, f32_to_u32
 
 class AIFCFile:
 
@@ -205,7 +205,7 @@ class AudioTableSample(AudioTableData):
         return ext
 
     def base_note_number(self):
-        return note_z64_to_midi(self.base_note)
+        return note_z64_to_midi(pitch_names.index(self.base_note))
 
     def resolve_basenote_rate(self, extraction_sample_info : Optional[Dict[str,str]]):
         assert len(self.notes_rates) != 0
@@ -287,7 +287,7 @@ class AudioTableSample(AudioTableData):
         if extraction_sample_info is not None:
             assert "SampleRate" in extraction_sample_info and "BaseNote" in extraction_sample_info
             final_rate = int(extraction_sample_info["SampleRate"])
-            final_note = pitch_names.index(extraction_sample_info["BaseNote"])
+            final_note = extraction_sample_info["BaseNote"]
 
         # print("     ",len(FINAL_NOTES_RATES), FINAL_NOTES_RATES)
         # if rate_3ds is not None and len(FINAL_NOTES_RATES) == 1:
@@ -644,7 +644,7 @@ class AudioTableFile:
                     "Name"       : sample.name,
                     "FileName"   : sample.filename.replace(sample.codec_file_extension_compressed(), ""),
                     "SampleRate" : sample.sample_rate,
-                    "BaseNote"   : pitch_names[sample.base_note],
+                    "BaseNote"   : sample.base_note,
                 }
                 xml.write_element("Sample", attrs)
             else:

--- a/tools/audio/extraction/tuning.py
+++ b/tools/audio/extraction/tuning.py
@@ -62,14 +62,8 @@ def note_z64_to_midi(note : int) -> int:
     """
     return (21 + note) % 128
 
-def recalc_tuning(rate : int, note : int) -> float:
-    # The tuning formula t(r,n) for n a midi note number is
-    #   t = (r / 32000) * 2^{60 - n}
-    # We use a lookup table for the power of 2 calculation for z a z64 note number
-    #   t = (r / 32000) * frequencies[78 - z]
-    # The offset by 78 comes from 2*(60 - 21) where 21 relates the z64 and midi note numbers
-    #   n = 21 + z
-    return f32(f32(rate / 32000.0) * u32_to_f32(g_pitch_frequencies[(78 - note) % 128]))
+def recalc_tuning(rate : int, note : str) -> float:
+    return f32(f32(rate / 32000.0) * u32_to_f32(g_pitch_frequencies[pitch_names.index(note)]))
 
 def rate_from_tuning(tuning : float) -> Tuple[Tuple[str,int]]:
     """
@@ -92,16 +86,14 @@ def rate_from_tuning(tuning : float) -> Tuple[Tuple[str,int]]:
         diff : int = abs(f32_to_u32(tuning2) - tuning_bits)
 
         if diff == 0:
-            matches.append((note_val, nominal_rate))
+            matches.append((pitch_names[note_val], nominal_rate))
         else:
-            diffs.append((diff, (note_val, nominal_rate)))
+            diffs.append((diff, (pitch_names[note_val], nominal_rate)))
 
     # search gPitchFrequencies LUT one by one. We don't exit as soon as a match is found as in general this procedure
     # only recovers the correct (rate,note) pair up to multiples of 2, to get the final value we want to select the
     # "best" of these pairs by an essentially arbitrary ranking (cf `rank_rates_notes`)
-    for i,freq_bits in enumerate(g_pitch_frequencies):
-        # Reflect the note value as in recalc_tuning
-        note_val = (78 - i) % 128
+    for note_val,freq_bits in enumerate(g_pitch_frequencies):
         freq : float = u32_to_f32(freq_bits)
 
         # compute the "nominal" samplerate for a given basenote by R = 32000 * (t / f)
@@ -130,68 +122,32 @@ def rank_rates_notes(layouts):
         """
         rank = 0
 
-        notes_named = [pitch_names[note] for note in notes]
-
-        if 'C4' in notes_named and rate > 10000:
+        if 'C4' in notes and rate > 10000:
             rank += 10000
-        elif 'C2' in notes_named and rate > 10000:
+        elif 'C2' in notes and rate > 10000:
             rank += 9500
-        elif 'D3' in notes_named and rate > 10000:
+        elif 'D3' in notes and rate > 10000:
             rank += 8500
-        elif 'D4' in notes_named and rate > 10000:
+        elif 'D4' in notes and rate > 10000:
             rank += 8000
-        elif 'C3' in notes_named and rate > 10000:
-            rank += 4000
-        elif 'C5' in notes_named and rate > 10000:
-            rank += 4000
-        elif 'D0' in notes_named:
-            rank += 3500
-        elif 'A9' in notes_named:
-            rank += 3000
-        elif 'A3' in notes_named:
-            rank += 2750
-        elif 'C6' in notes_named:
-            rank += 2750
-        elif 'C8' in notes_named:
-            rank += 2500
-        elif 'C1' in notes_named:
-            rank += 2500
-        elif 'A4' in notes_named:
-            rank += 2500
-        elif 'A0' in notes_named:
-            rank += 2250
-        elif 'B0' in notes_named:
-            rank += 2250
-        elif 'AF9' in notes_named:
+        elif 'G3' in notes:
             rank += 2000
-        elif 'AF0' in notes_named:
-            rank += 2000
-        elif 'G3' in notes_named:
-            rank += 2000
-        elif 'GF4' in notes_named:
-            rank += 100
-        elif 'F9' in notes_named:
-            rank += 50
-        elif 'F3' in notes_named:
+        elif 'F3' in notes:
             rank += 25
-        elif 'C0' in notes_named:
+        elif 'C0' in notes:
             rank += 50
-        elif 'BF2' in notes_named:
+        elif 'BF2' in notes:
             rank += 30
-        elif 'B3' in notes_named:
+        elif 'B3' in notes:
             rank += 25
-        elif 'BF1' in notes_named:
+        elif 'BF1' in notes:
             rank += 25
-        elif 'E2' in notes_named:
+        elif 'E2' in notes:
             rank += 20
-        elif 'F6' in notes_named:
+        elif 'F6' in notes:
             rank += 15
-        elif 'GF2' in notes_named:
+        elif 'GF2' in notes:
             rank += 10
-        elif 'BF3' in notes_named:
-            rank += 1
-        elif 'AF2' in notes_named:
-            rank += 1
 
         rank += {
             32000 : 200,
@@ -220,7 +176,7 @@ def rank_rates_notes(layouts):
     ranked = list(sorted(layouts, key=lambda L : rank_rate_note(*L), reverse=True))
 
     # Ensure the ranking produced a unique best option
-    assert rank_rate_note(*ranked[0]) != rank_rate_note(*ranked[1]) , [(rate,tuple(pitch_names[note] for note in notes)) for rate,notes in ranked]
+    assert rank_rate_note(*ranked[0]) != rank_rate_note(*ranked[1]) , ranked
 
     # Output best
     return ranked[0]
@@ -229,7 +185,7 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(description="Given either a (rate,note) or a tuning, compute all matching rates/notes.")
-    parser.add_argument("-t", dest="tuning", required=False, default=None, help="Tuning value (float or hex)")
+    parser.add_argument("-t", dest="tuning", required=False, default=None, type=float, help="Tuning value (float)")
     parser.add_argument("-r", dest="rate", required=False, default=None, type=int, help="Sample rate (integer)")
     parser.add_argument("-n", dest="note", required=False, default=None, type=str, help="Base note (note name)")
     parser.add_argument("--show-result", required=False, default=False, action="store_true", help="Show recalculated tuning value")
@@ -237,10 +193,10 @@ if __name__ == '__main__':
 
     if args.tuning is not None:
         # Take input tuning
-        tuning : float = u32_to_f32(int(args.tuning,16)) if args.tuning.startswith("0x") else float(args.tuning)
+        tuning = args.tuning
     elif args.rate is not None and args.note is not None:
         # Calculate target tuning from input rate and note
-        tuning : float = recalc_tuning(args.rate, pitch_names.index(args.note))
+        tuning : float = recalc_tuning(args.rate, args.note)
     else:
         # Insufficient arguments
         parser.print_help()
@@ -250,6 +206,6 @@ if __name__ == '__main__':
 
     for note,rate in notes_rates:
         if args.show_result:
-            print(rate, pitch_names[note], "->", recalc_tuning(rate, note))
+            print(rate, note, "->", recalc_tuning(rate, note))
         else:
-            print(rate, pitch_names[note])
+            print(rate, note)

--- a/tools/audio/soundfont_compiler.c
+++ b/tools/audio/soundfont_compiler.c
@@ -199,8 +199,7 @@ calc_tuning(float sample_rate, int basenote, int8_t finetune)
         /* 0x7F */ 0.099213f,   // PITCH_AF0
     };
 
-    // Due to the way the lookup table is arranged, the note needs to be reflected about middle C (z64 note value 39)
-    float tuning = (sample_rate / playback_sample_rate) * pitch_frequencies[(78u - (unsigned)basenote) % 128u];
+    float tuning = (sample_rate / playback_sample_rate) * pitch_frequencies[basenote];
     if (finetune == 0)
         return tuning;
 
@@ -1447,10 +1446,10 @@ emit_c_drums(FILE *out, soundfont *sf)
             ptr_table[ptr_offset].n = note_offset;
 
             // wrap note on overflow
-            // drum frequencies increase with drum offset, corresponding to a decrease in note number
-            int note = drum->base_note - note_offset;
-            if (note < 0)
-                note += 128;
+            int note = drum->base_note + note_offset;
+            if (note > 127)
+                note -= 128;
+
             float tuning = calc_tuning(drum->sample_rate, note, drum->fine_tune);
 
             fprintf(out, "    SF%d_%s_ENTRY(" F32_FMT "f),\n", sf->info.index, drum->name, tuning);


### PR DESCRIPTION
Isolate and remove the "Audio: Fix note values" commit (decomp: https://github.com/zeldaret/oot/pull/2716) introduced by the recent rebase (#275)

This change introduced by the OoT decomp is useless if it's also not applied MM decomp. Importing soundfonts from MM with the old note values will make it sound wrong, and causes for example the tracks heard in Woodfall and Woodfall Temple to have the wrong pitches used in instruments.