### PR TITLE
Fix spec & DMA request issues

### DIFF
--- a/spec/extra_scenes.inc
+++ b/spec/extra_scenes.inc
@@ -455,12 +455,14 @@ endseg
 
 beginseg
     name "mountain_smithy_scene"
+    compress
     include "$(BUILD_DIR)/assets/scenes/indoors/mountain_smithy/mountain_smithy_scene.o"
     number 2
 endseg
 
 beginseg
     name "mountain_smithy_room_0"
+    compress
     include "$(BUILD_DIR)/assets/scenes/indoors/mountain_smithy/mountain_smithy_room_0.o"
     number 3
 endseg

--- a/spec/spec
+++ b/spec/spec
@@ -437,9 +437,6 @@ endseg
 
 beginseg
     name "nes_font_static"
-#if !PLATFORM_IQUE
-    compress
-#endif
     #if OOT_NTSC_N64
     include "$(BUILD_DIR)/assets/textures/nes_font_static/nes_font_static_all.o"
     #else
@@ -860,7 +857,6 @@ endseg
 
 beginseg
     name "buffers"
-    compress
     flags NOLOAD
     align 0x40
     include "$(BUILD_DIR)/src/buffers/zbuffer.o"
@@ -981,7 +977,6 @@ endseg
 
 beginseg
     name "vr_fine0_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_fine0_pal_static.o"
 endseg
 
@@ -993,7 +988,6 @@ endseg
 
 beginseg
     name "vr_fine1_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_fine1_pal_static.o"
 endseg
 
@@ -1005,7 +999,6 @@ endseg
 
 beginseg
     name "vr_fine2_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_fine2_pal_static.o"
 endseg
 
@@ -1017,7 +1010,6 @@ endseg
 
 beginseg
     name "vr_fine3_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_fine3_pal_static.o"
 endseg
 
@@ -1029,7 +1021,6 @@ endseg
 
 beginseg
     name "vr_cloud0_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_cloud0_pal_static.o"
 endseg
 
@@ -1041,7 +1032,6 @@ endseg
 
 beginseg
     name "vr_cloud1_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_cloud1_pal_static.o"
 endseg
 
@@ -1053,7 +1043,6 @@ endseg
 
 beginseg
     name "vr_cloud2_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_cloud2_pal_static.o"
 endseg
 
@@ -1065,7 +1054,6 @@ endseg
 
 beginseg
     name "vr_cloud3_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_cloud3_pal_static.o"
 endseg
 
@@ -1077,7 +1065,6 @@ endseg
 
 beginseg
     name "vr_holy0_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_holy0_pal_static.o"
 endseg
 
@@ -1089,7 +1076,6 @@ endseg
 
 beginseg
     name "vr_holy1_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/skyboxes/vr_holy1_pal_static.o"
 endseg
 
@@ -1101,7 +1087,6 @@ endseg
 
 beginseg
     name "vr_MDVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_MDVR_pal_static.o"
 endseg
 
@@ -1113,7 +1098,6 @@ endseg
 
 beginseg
     name "vr_MNVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_MNVR_pal_static.o"
 endseg
 
@@ -1125,7 +1109,6 @@ endseg
 
 beginseg
     name "vr_RUVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_RUVR_pal_static.o"
 endseg
 
@@ -1137,7 +1120,6 @@ endseg
 
 beginseg
     name "vr_LHVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_LHVR_pal_static.o"
 endseg
 
@@ -1149,7 +1131,6 @@ endseg
 
 beginseg
     name "vr_KHVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_KHVR_pal_static.o"
 endseg
 
@@ -1161,7 +1142,6 @@ endseg
 
 beginseg
     name "vr_K3VR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_K3VR_pal_static.o"
 endseg
 
@@ -1173,7 +1153,6 @@ endseg
 
 beginseg
     name "vr_K4VR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_K4VR_pal_static.o"
 endseg
 
@@ -1185,7 +1164,6 @@ endseg
 
 beginseg
     name "vr_K5VR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_K5VR_pal_static.o"
 endseg
 
@@ -1197,7 +1175,6 @@ endseg
 
 beginseg
     name "vr_SP1a_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_SP1a_pal_static.o"
 endseg
 
@@ -1209,7 +1186,6 @@ endseg
 
 beginseg
     name "vr_MLVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_MLVR_pal_static.o"
 endseg
 
@@ -1221,7 +1197,6 @@ endseg
 
 beginseg
     name "vr_KKRVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_KKRVR_pal_static.o"
 endseg
 
@@ -1233,7 +1208,6 @@ endseg
 
 beginseg
     name "vr_KR3VR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_KR3VR_pal_static.o"
 endseg
 
@@ -1245,7 +1219,6 @@ endseg
 
 beginseg
     name "vr_IPVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_IPVR_pal_static.o"
 endseg
 
@@ -1268,7 +1241,6 @@ endseg
 
 beginseg
     name "vr_GLVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_GLVR_pal_static.o"
 endseg
 
@@ -1280,7 +1252,6 @@ endseg
 
 beginseg
     name "vr_ZRVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_ZRVR_pal_static.o"
 endseg
 
@@ -1292,7 +1263,6 @@ endseg
 
 beginseg
     name "vr_DGVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_DGVR_pal_static.o"
 endseg
 
@@ -1304,7 +1274,6 @@ endseg
 
 beginseg
     name "vr_ALVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_ALVR_pal_static.o"
 endseg
 
@@ -1316,7 +1285,6 @@ endseg
 
 beginseg
     name "vr_NSVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_NSVR_pal_static.o"
 endseg
 
@@ -1328,7 +1296,6 @@ endseg
 
 beginseg
     name "vr_LBVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_LBVR_pal_static.o"
 endseg
 
@@ -1340,7 +1307,6 @@ endseg
 
 beginseg
     name "vr_TTVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_TTVR_pal_static.o"
 endseg
 
@@ -1352,7 +1318,6 @@ endseg
 
 beginseg
     name "vr_FCVR_pal_static"
-    compress
     include "$(BUILD_DIR)/assets/textures/backgrounds/vr_FCVR_pal_static.o"
 endseg
 

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -183,7 +183,7 @@ void Interface_Init(PlayState* play) {
     else if (CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD) == PLAYER_SHIELD_HEROS)
         item = ITEM_SHIELD_HEROS;
     else item = ITEM_NONE;
-    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (9 * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(Interface_LoadItemIconChildQuest(item)), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, __FILE__, __LINE__);
+    DMA_REQUEST_SYNC(interfaceCtx->iconItemSegment + (9 * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(Interface_LoadItemIconChildQuest(item)), ITEM_ICON_SIZE, __FILE__, __LINE__);
 
     PRINTF("ＥＶＥＮＴ＝%d\n", ((void)0, gSaveContext.timerState));
 

--- a/src/code/z_inventory.c
+++ b/src/code/z_inventory.c
@@ -308,7 +308,6 @@ void Inventory_ChangeEquipmentWithIcon(PlayState* play, s16 equipment, u16 value
 
     if (equipment == EQUIP_TYPE_SHIELD) {
         u8 shieldItem;
-        InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
         if (value == PLAYER_SHIELD_DEKU)
             shieldItem = ITEM_SHIELD_DEKU;
@@ -320,7 +319,7 @@ void Inventory_ChangeEquipmentWithIcon(PlayState* play, s16 equipment, u16 value
             shieldItem = ITEM_SHIELD_HEROS;
         else shieldItem = ITEM_NONE;
 
-        DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (9 * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(Interface_LoadItemIconChildQuest(shieldItem)), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, __FILE__, __LINE__);
+        DMA_REQUEST_SYNC(play->interfaceCtx.iconItemSegment + (9 * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(Interface_LoadItemIconChildQuest(shieldItem)), ITEM_ICON_SIZE, __FILE__, __LINE__);
     }
 }
 

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12528,7 +12528,7 @@ void Player_DetectRumbleSecrets(Player* this, PlayState* play) {
                 if (play->specialIconLast != SPECIAL_ICON_RUMBLE) {
                     InterfaceContext* interfaceCtx = &play->interfaceCtx;
                     play->specialIconLast = SPECIAL_ICON_RUMBLE;
-                    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (8 * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(Interface_LoadItemIconChildQuest(ITEM_STONE_OF_AGONY)), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1171);
+                    DMA_REQUEST_ASYNC(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + (8 * ITEM_ICON_SIZE), GET_ITEM_ICON_VROM(Interface_LoadItemIconChildQuest(ITEM_STONE_OF_AGONY)), ITEM_ICON_SIZE, 0, &interfaceCtx->loadQueue, NULL, __FILE__, __LINE__);
                 }
                 if (play->specialIconCount == 0)
                     play->specialIconCount++;


### PR DESCRIPTION
Fix four issues with the spec:
- Do not compress nes_font_static anymore, it causes PAL 1.0 to crash when compressed
- Do not compress buffers anymore, it causes PAL 1.0 to crash when compressed
- Do not compress the pal_static skyboxes anymore, it causes PAL 1.0 to crash when compressed
- Compress the Spring Lake Smithy scene

Also fixes issues with calling DMA_REQUEST_ASYNC for the shield durability icon (changed to DMA_REQUEST_SYNC to fix). Might be good to test if doing a sync call doesn't cause any slowdowns.