### PR TITLE
Fix Beamos health

### DIFF
--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.c
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.c
@@ -406,7 +406,9 @@ void EnVm_CheckHealth(EnVm* this, PlayState* play) {
     EnBom* bomb;
 
     if (Actor_GetCollidedExplosive(play, &this->colliderCylinder.base) != NULL) {
-        this->actor.colChkInfo.health -= DAMAGE_MULTIPLY;
+        if (this->actor.colChkInfo.health <= DAMAGE_MULTIPLY)
+            this->actor.colChkInfo.health = 0;
+        else this->actor.colChkInfo.health -= DAMAGE_MULTIPLY;
         PRINTF("hp down %d\n", this->actor.colChkInfo.health);
     } else {
         if (!(this->colliderQuad2.base.acFlags & AC_HIT) || this->unk_21C == 2) {


### PR DESCRIPTION
Beamos health works a bit differently. Only bombs can damage a Beamos, but they don't use a damage table so instead only 1 health is extracted. Small beamos have 1 health and large beamos have 2 health. So 1 or 2 bombs will kill one since that would have their health decremented to 0, and the beamos only checks if health has reached exactly 0.

There are two changes to DX here that change how health behaves:
- Health multiplication up to 5x or even 0.5x.
- Increased damage to enemies and their health by 10x

The health multiplication works fine. A small beamos would 5x health just need 5 bombs to die.

The increased damage and health by 10x works fine too. A beamos of 1 health will now have 10 health, but bombs will also extract 10 health instead of 1. So still one bomb.

The issue comes when the health is set to 0.5x. Since damage and health is still multiplied by 10x the beamos would now have 5 health (10/2=5), where previously it stayed at 1 health, since health has to be a whole number and got rounded up to 1. But bombs still do 10 damage. So the first bomb reduces the beamos health to -5, and since the beamos only checks when his health is exactly 0 he will never die.

The fix is simple. When reducing it's health after a bomb, check if his health doesn't reach below 0 or otherwise set it to 0.