### PR TITLE
Sword Beam on B slash for Hero's Sword

### DIFF
--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -70,8 +70,9 @@ static ColliderCylinderInit sCylinderInit = {
     { 200, 200, 0, { 0, 0, 0 } },
 };
 
-static u32 sSpinAttackDmgFlags[] = { DMG_SPIN_MASTER, DMG_SPIN_KOKIRI, DMG_SPIN_GIANT, DMG_SPIN_GIANT };
-static u32 sJumpAttackDmgFlags[] = { DMG_JUMP_MASTER, DMG_JUMP_KOKIRI, DMG_JUMP_GIANT, DMG_JUMP_GIANT };
+static u32 sSpinAttackDmgFlags[] = { DMG_SPIN_MASTER, DMG_SPIN_KOKIRI, DMG_SPIN_GIANT, DMG_DEKU_STICK,  DMG_HAMMER_SWING, DMG_SPIN_GIANT };
+static u32 sJumpAttackDmgFlags[] = { DMG_JUMP_MASTER, DMG_JUMP_KOKIRI, DMG_JUMP_GIANT, DMG_JUMP_MASTER, DMG_HAMMER_JUMP,  DMG_JUMP_GIANT };
+static u8  sThunderDustType[]    = { 2, 3, 4, 4, 4, 4 };
 
 typedef enum {
     /* 0 */ ENMTHUNDER_SUBTYPE_SPIN_GREAT,
@@ -92,7 +93,7 @@ void EnMThunder_Init(Actor* thisx, PlayState* play2) {
 
     Collider_InitCylinder(play, &this->collider);
     Collider_SetCylinder(play, &this->collider, &this->actor, &sCylinderInit);
-    this->swordType = PARAMS_GET_S(this->actor.params, 0, 8) - 1;
+    this->swordType = PARAMS_GET_S(this->actor.params, 0, 7) - 1;
     Lights_PointNoGlowSetInfo(&this->lightInfo, this->actor.world.pos.x, this->actor.world.pos.y,
                               this->actor.world.pos.z, 255, 255, 255, 0);
     this->lightNode = LightContext_InsertLight(play, &play->lightCtx, &this->lightInfo);
@@ -108,6 +109,7 @@ void EnMThunder_Init(Actor* thisx, PlayState* play2) {
     this->actor.room = -1;
     Actor_SetScale(&this->actor, 0.1f);
     this->isUsingMagic = false;
+    this->isBeam = (thisx->params & 0x80) != 0;
 
     if (player->stateFlags2 & PLAYER_STATE2_17) {
         if (!gSaveContext.save.info.playerData.isMagicAcquired || (gSaveContext.magicState != MAGIC_STATE_IDLE) ||
@@ -133,12 +135,12 @@ void EnMThunder_Init(Actor* thisx, PlayState* play2) {
             case 2: // Gilded Sword / Giant's Knife
                 this->targetScale = IS_CHILD_QUEST_AS_CHILD ? 3 : 4;
                 break;
-            case 3: // Great Fairy's Sword
+            case 5: // Great Fairy's Sword
                 this->targetScale = 4;
                 break;
         }
 
-        if (HAS_HEROS_SWORD && CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) == EQUIP_VALUE_SWORD_KOKIRI && player->itemAction == PLAYER_IA_SWORD_KOKIRI) {
+        if (this->isBeam) {
             this->attackStrength += 2;
             this->actor.flags |= ACTOR_FLAG_UPDATE_CULLING_DISABLED;
             EnMThunder_SetupAction(this, EnMThunder_SwordBeam_Attack);
@@ -254,7 +256,7 @@ void EnMThunder_ChargingSpinAttack(EnMThunder* this, PlayState* play) {
                 case 2: // Gilded Sword / Giant's Knife
                     this->targetScale = IS_CHILD_QUEST_AS_CHILD ? 3 : 4;
                     break;
-                case 3: // Great Fairy's Sword
+                case 5: // Great Fairy's Sword
                     this->targetScale = 4;
                     break;
             }
@@ -268,7 +270,7 @@ void EnMThunder_ChargingSpinAttack(EnMThunder* this, PlayState* play) {
                 this->targetScale *= 2;
             }
 
-            if (HAS_HEROS_SWORD && CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) == EQUIP_VALUE_SWORD_KOKIRI) {
+            if (this->isBeam) {
                 this->attackStrength += 2;
                 this->actor.flags |= ACTOR_FLAG_UPDATE_CULLING_DISABLED;
                 EnMThunder_SetupAction(this, EnMThunder_SwordBeam_Attack);
@@ -308,7 +310,7 @@ void EnMThunder_ChargingSpinAttack(EnMThunder* this, PlayState* play) {
         if (this->actor.child == NULL) {
             Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_EFF_DUST, this->actor.world.pos.x,
                                this->actor.world.pos.y, this->actor.world.pos.z, 0, this->actor.shape.rot.y, 0,
-                               this->swordType + 2);
+                               sThunderDustType[this->swordType]);
         }
         this->dimmingIntensity += ((((player->unk_858 - 0.15f) * 1.5f) - this->dimmingIntensity) * 0.5f);
 
@@ -429,6 +431,9 @@ void EnMThunder_Update(Actor* thisx, PlayState* play) {
     s32 redGreen;
 
     this->actionFunc(this, play);
+    if (this->isBeam)
+        return;
+
     EnMThunder_AdjustEnvLights(play, this->dimmingIntensity);
     blueRadius = this->spinAttackTimer;
     redGreen = (u32)(blueRadius * 255.0f) & 0xFF;
@@ -519,7 +524,7 @@ void EnMThunder_Draw(Actor* thisx, PlayState* play2) {
                 Matrix_RotateX(16384.0f, MTXMODE_APPLY);
             }
             break;
-        case 3:
+        case 5: // Great Fairy's Sword
             Matrix_Translate(200.0f, 350.0f, 0.0f, MTXMODE_APPLY);
             Matrix_Scale(-1.8f, -1.4f, -0.7f, MTXMODE_APPLY);
             Matrix_RotateX(16384.0f, MTXMODE_APPLY);

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
@@ -26,6 +26,7 @@ typedef struct EnMThunder {
     /* 0x01C8 */ u8 chargeAlpha;
     /* 0x01C9 */ u8 targetScale;
     /* 0x01CA */ u8 isUsingMagic;
+    /* 0x01CB */ bool isBeam;
 } EnMThunder; // size = 0x01CC
 
 #endif

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4919,10 +4919,6 @@ s32 Player_TryActionInterrupt(PlayState* play, Player* this, SkelAnime* skelAnim
 }
 
 void func_80837530(PlayState* play, Player* this, s32 arg2) {
-    u8 meleeWeapon = Player_GetMeleeWeaponHeld(this);
-    if (meleeWeapon == 6)
-        meleeWeapon = 4;
-
     if (arg2 != 0) {
         this->unk_858 = 0.0f;
     } else {
@@ -4934,7 +4930,22 @@ void func_80837530(PlayState* play, Player* this, s32 arg2) {
     if (this->actor.category == ACTORCAT_PLAYER) {
         Actor_Spawn(&play->actorCtx, play, ACTOR_EN_M_THUNDER, this->bodyPartsPos[PLAYER_BODYPART_WAIST].x,
                     this->bodyPartsPos[PLAYER_BODYPART_WAIST].y, this->bodyPartsPos[PLAYER_BODYPART_WAIST].z, 0, 0, 0,
-                    meleeWeapon | arg2);
+                    Player_GetMeleeWeaponHeld(this) | arg2);
+    }
+}
+
+void Player_SwordBeam(PlayState* play, Player* this, s32 magicCost) {
+    if (!gSaveContext.save.info.playerData.isMagicAcquired || gSaveContext.save.info.playerData.magic < magicCost || gSaveContext.magicState != MAGIC_STATE_IDLE)
+        return;
+
+    this->unk_858 = magicCost != 0 ? 0.0f : 0.5;
+    this->stateFlags1 |= PLAYER_STATE1_CHARGING_SPIN_ATTACK;
+
+    if (this->actor.category == ACTORCAT_PLAYER) {
+        s16 pitch = 0;
+        if (this->focusActor != NULL)
+            pitch = Math_Vec3f_Pitch(&this->bodyPartsPos[PLAYER_BODYPART_WAIST], &this->focusActor->focus.pos);
+        Actor_Spawn(&play->actorCtx, play, ACTOR_EN_M_THUNDER, this->bodyPartsPos[PLAYER_BODYPART_WAIST].x, this->bodyPartsPos[PLAYER_BODYPART_WAIST].y, this->bodyPartsPos[PLAYER_BODYPART_WAIST].z, pitch, 0, 0, Player_GetMeleeWeaponHeld(this) | (magicCost << 8) | 0x80);
     }
 }
 
@@ -15693,6 +15704,9 @@ s32 Player_ActionHandler_7(Player* this, PlayState* play) {
                 this->stateFlags2 |= PLAYER_STATE2_17;
                 func_80837530(play, this, 0);
                 return 1;
+            } else if (HAS_HEROS_SWORD && this->itemAction == PLAYER_IA_SWORD_KOKIRI) {
+                this->stateFlags2 |= PLAYER_STATE2_17;
+                Player_SwordBeam(play, this, 0);
             }
         } else {
             return 0;


### PR DESCRIPTION
Reworkes the sword beam to function on slashing the sword (just press B) rather than charging it.

Only the Hero's Sword can still do sword beams. Now that slashes do sword beams, the charge is restored to a spin attack again.

Additionally the sword spin actor logic has been adjusted to fix the Great Fairy's Sword from crashing, because it was passing through the wrong dust type. The Great Fairy's Sword is now using type 6, the type which passed through by Player_GetMeleeWeaponHeld instead of forcing it to 4, so the actor now accounts for having the Deku Stick and Megaton Hammer inbetween, but this remains otherwise incomplete (not needed, since these weapons can not spin, the Great Fairy's Sword could spin by using a trick by pressing and holding B right after you pressed it's C button).