### PR TITLE
Check Alternative D-Pad Set for Masks

### DIFF
--- a/include/save.h
+++ b/include/save.h
@@ -489,7 +489,8 @@ typedef enum LinkAge {
 
 #define SCENE_LAYER_GOTO(play, layer) (IS_CHILD_QUEST_AS_CHILD && !IS_CUTSCENE_LAYER ? !IS_DAY : layer)
 
-#define DPAD_BUTTON(button)      (gSaveContext.save.info.playerData.dpadItems[gSaveContext.save.linkAge + gSaveContext.save.info.playerData.dpadDualSet * 2][button])
+#define DPAD_BUTTON(button)             (gSaveContext.save.info.playerData.dpadItems[gSaveContext.save.linkAge + gSaveContext.save.info.playerData.dpadDualSet * 2][button])
+#define DPAD_BUTTON_SET(button, set)    (gSaveContext.save.info.playerData.dpadItems[gSaveContext.save.linkAge + set                                           * 2][button])
 
 // Usage in Map Select suggests that `gSaveContext.save.cutsceneIndex` was,
 // at one point in development, a variable related to the time.

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1816,34 +1816,40 @@ u8 Interface_LoadItemIconChildQuest(u8 item) {
 }
 
 u8 Interface_GetItemFromDpad(u8 button) {
+    bool set = gSaveContext.save.info.playerData.dpadDualSet;
+    if (button > 4)  {
+        button -= 4;
+        set = !set;
+    }
+
     if (!IS_CHILD_QUEST) {
-        if (DPAD_BUTTON(button) == SLOT_ARROW_FIRE)
+        if (DPAD_BUTTON_SET(button, set) == SLOT_ARROW_FIRE)
             return (gSaveContext.save.info.inventory.items[SLOT_ARROW_FIRE]  == ITEM_ARROW_FIRE)  ? ITEM_BOW_FIRE  : ITEM_NONE;
-        else if (DPAD_BUTTON(button) == SLOT_ARROW_ICE)
+        else if (DPAD_BUTTON_SET(button, set) == SLOT_ARROW_ICE)
             return (gSaveContext.save.info.inventory.items[SLOT_ARROW_ICE]   == ITEM_ARROW_ICE)   ? ITEM_BOW_ICE   : ITEM_NONE;
-        else if (DPAD_BUTTON(button) == SLOT_ARROW_LIGHT)
+        else if (DPAD_BUTTON_SET(button, set) == SLOT_ARROW_LIGHT)
             return( gSaveContext.save.info.inventory.items[SLOT_ARROW_LIGHT] == ITEM_ARROW_LIGHT) ? ITEM_BOW_LIGHT : ITEM_NONE;
     }
 
-    if (DPAD_BUTTON(button) == SLOT_TRADE_CHILD)
+    if (DPAD_BUTTON_SET(button, set) == SLOT_TRADE_CHILD)
         return (gSaveContext.save.info.inventory.items[SLOT_TRADE_CHILD] >= ITEM_WEIRD_EGG && gSaveContext.save.info.inventory.items[SLOT_TRADE_CHILD] <= ITEM_MASK_TRUTH) ? gSaveContext.save.info.inventory.items[SLOT_TRADE_CHILD] : ITEM_NONE;
-    else if (DPAD_BUTTON(button) < SLOT_SWORDS)
-        return gSaveContext.save.info.inventory.items[DPAD_BUTTON(button)];
-    else if (DPAD_BUTTON(button) == SLOT_SWORDS)
+    else if (DPAD_BUTTON_SET(button, set) < SLOT_SWORDS)
+        return gSaveContext.save.info.inventory.items[DPAD_BUTTON_SET(button, set)];
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_SWORDS)
         return ITEM_SWORDS;
-    else if (DPAD_BUTTON(button) == SLOT_SHIELDS)
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_SHIELDS)
         return ITEM_SHIELDS;
-    else if (DPAD_BUTTON(button) == SLOT_TUNICS)
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_TUNICS)
         return ITEM_TUNICS;
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS)
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_BOOTS)
         return ITEM_BOOTS;
-    else if (DPAD_BUTTON(button) == SLOT_TUNIC_GORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON))
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_TUNIC_GORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON))
         return ITEM_TUNIC_GORON;
-    else if (DPAD_BUTTON(button) == SLOT_TUNIC_ZORA  && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA))
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_TUNIC_ZORA  && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_ZORA))
         return ITEM_TUNIC_ZORA;
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS_IRON  && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON))
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_BOOTS_IRON  && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON))
         return ITEM_BOOTS_IRON;
-    else if (DPAD_BUTTON(button) == SLOT_BOOTS_HOVER && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER))
+    else if (DPAD_BUTTON_SET(button, set) == SLOT_BOOTS_HOVER && CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_HOVER))
         return ITEM_BOOTS_HOVER;
     else return ITEM_NONE;
 }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3156,8 +3156,9 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
 
         if (!Player_ItemIsItemAction(C_BTN_ITEM(0), maskItemAction) &&
             !Player_ItemIsItemAction(C_BTN_ITEM(1), maskItemAction) &&
-            !Player_ItemIsItemAction(C_BTN_ITEM(2), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(0), maskItemAction) &&
-            !Player_ItemIsItemAction(Interface_GetItemFromDpad(1), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(2), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(3), maskItemAction) ) {
+            !Player_ItemIsItemAction(C_BTN_ITEM(2), maskItemAction) &&
+            !Player_ItemIsItemAction(Interface_GetItemFromDpad(0), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(1), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(2), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(3), maskItemAction) &&
+            !Player_ItemIsItemAction(Interface_GetItemFromDpad(4), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(5), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(6), maskItemAction) && !Player_ItemIsItemAction(Interface_GetItemFromDpad(7), maskItemAction) ) {
             this->currentMask = PLAYER_MASK_NONE;
             SET_MASK_AGE(this->currentMask);
         }


### PR DESCRIPTION
Masks can only stay equipped if it's set to a C or D-Pad button, but the alternate D-Pad set wasn't accounted for. So if you switched to the alternate D-Pad set (without having a Mask on a C button) then the mask would unequip.

With this PR mask now respect checking the other D-Pad set. So as long you have a mask on a C button or any of the two D-Pad sets the mask would stay on.