### PR TITLE
Spaceworld scenes fixes

### DIFF
--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_0.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_0.c
@@ -36,26 +36,25 @@ s16 fairy_deku_tree_room_0ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_0ActorList0x000048[] = {
-    { ACTOR_OBJ_SWITCH,    { -784,  741,  783 }, { 0, 0x5FFF, 0 }, 0x0002 },
-    { ACTOR_OBJ_SWITCH,    { -343, 1029,  601 }, { 0, 0xE000, 0 }, 0x0202 },
-    { ACTOR_OBJ_SWITCH,    {  785, 1291,  781 }, { 0, 0xA001, 0 }, 0x0302 },
-    { ACTOR_BG_YDAN_HASI2, {  549, 1400,  549 }, { 0, 0x0FA5, 0 }, 0x001E },
-    { ACTOR_EN_DEKUBABA,   {  975,    0,  313 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,   {  205,  400,  501 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,   {  211,  520, -492 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,   { -480,  920, -231 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,   { -236, 1524, -462 }, { 0,      0, 0 }, 0x0001 },
-    { ACTOR_EN_BOX,        {   25, 1680,   18 }, { 0, 0xA000, 0 }, 0x27E0 },
-    { ACTOR_EN_DEKUBABA,   { -759,    0,  232 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,   { -948,    0,  288 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_EN_ITEM00,     {  346,  800,  360 }, { 0,      0, 0 }, 0x0003 },
-    { ACTOR_OBJ_SWITCH,    { 1112,  971,   -4 }, { 0, 0xC000, 0 }, 0x0502 },
-    { ACTOR_EN_KO,         {   55, 1680,   50 }, { 0, 0x2000, 0 }, 0x000C },
-    { ACTOR_EN_FIREFLY,    { -185, 1980,  300 }, { 0, 0x4000, 0 }, 0x0005 },
-    { ACTOR_EN_FIREFLY,    {  185, 1980,  300 }, { 0, 0xC000, 0 }, 0x0005 },
-    { ACTOR_EN_FIREFLY,    {  -15, 1980, -200 }, { 0,      0, 0 }, 0x0005 },
-    { ACTOR_EN_FIREFLY,    {  100, 1980,  400 }, { 0, 0x8000, 0 }, 0x0005 },
-    
+    { ACTOR_OBJ_SWITCH,    { -784,  741,  783 }, {    0, 0x5FFF, 0 }, 0x0002 }, // Switch: 00
+    { ACTOR_OBJ_SWITCH,    { -343, 1029,  601 }, {    0, 0xE000, 0 }, 0x0202 }, // Switch: 02
+    { ACTOR_OBJ_SWITCH,    {  785, 1291,  781 }, {    0, 0xA001, 0 }, 0x0302 }, // Switch: 03
+    { ACTOR_OBJ_SWITCH,    { 1112,  971,   -4 }, {    0, 0xC000, 0 }, 0x0502 }, // Switch: 05
+    { ACTOR_BG_YDAN_HASI2, {  549, 1400,  549 }, {    0, 0x0FA5, 0 }, 0x001E }, // Switch: 1E
+    { ACTOR_EN_BOX,        {   25, 1680,   18 }, { 0x3F, 0xA000, 0 }, 0x2000 }, // Chest: 00, Boss Key
+    { ACTOR_EN_ITEM00,     {  346,  800,  360 }, {    0,      0, 0 }, 0x2003 }, // Collectible: 20, Red Rupee
+    { ACTOR_EN_KO,         {   55, 1680,   50 }, {    0, 0x2000, 0 }, 0x000C },
+    { ACTOR_EN_DEKUBABA,   {  975,    0,  313 }, {    0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,   {  205,  400,  501 }, {    0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,   {  211,  520, -492 }, {    0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,   { -480,  920, -231 }, {    0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,   { -236, 1524, -462 }, {    0,      0, 0 }, 0x0001 },
+    { ACTOR_EN_DEKUBABA,   { -759,    0,  232 }, {    0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,   { -948,    0,  288 }, {    0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_FIREFLY,    { -185, 1980,  300 }, {    0, 0x4000, 0 }, 0x0005 },
+    { ACTOR_EN_FIREFLY,    {  185, 1980,  300 }, {    0, 0xC000, 0 }, 0x0005 },
+    { ACTOR_EN_FIREFLY,    {  -15, 1980, -200 }, {    0,      0, 0 }, 0x0005 },
+    { ACTOR_EN_FIREFLY,    {  100, 1980,  400 }, {    0, 0x8000, 0 }, 0x0005 },
 };
 
 RoomShapeCullable fairy_deku_tree_room_0MeshHeader0x000150 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_1.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_1.c
@@ -31,11 +31,11 @@ s16 fairy_deku_tree_room_1ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_1ActorList0x000048[] = {
-    { ACTOR_EN_DEKUBABA,  {    8, 0,  -75 }, { 0, 0, 0 }, 0x0001 },
-    { ACTOR_EN_BOX,       {    7, 0,  162 }, { 0, 0, 0 }, 0x5041 },
-    { ACTOR_OBJ_SYOKUDAI, {  138, 0,   33 }, { 0, 0, 0 }, 0x1088 },
-    { ACTOR_OBJ_SYOKUDAI, { -127, 0,   33 }, { 0, 0, 0 }, 0x1088 },
-    { ACTOR_OBJ_SYOKUDAI, {   11, 0, -219 }, { 0, 0, 0 }, 0x27FF },
+    { ACTOR_EN_DEKUBABA,  {    8, 0,  -75 }, {   0, 0, 0 }, 0x0001 },
+    { ACTOR_EN_BOX,       {    7, 0,  162 }, { 0x2, 0, 0 }, 0x5001 }, // Chest: 01, Deku Nuts
+    { ACTOR_OBJ_SYOKUDAI, {  138, 0,   33 }, {   0, 0, 0 }, 0x1088 }, // Switch: 08
+    { ACTOR_OBJ_SYOKUDAI, { -127, 0,   33 }, {   0, 0, 0 }, 0x1088 }, // Switch: 08
+    { ACTOR_OBJ_SYOKUDAI, {   11, 0, -219 }, {   0, 0, 0 }, 0x27FF },
 };
 
 RoomShapeCullable fairy_deku_tree_room_1MeshHeader0x0000A0 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_10.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_10.c
@@ -34,11 +34,11 @@ ActorEntry fairy_deku_tree_room_10ActorList0x000048[] = {
     { ACTOR_EN_ST,        {  -496, 1354, 1462 }, { 0, 0xC000, 0 }, 0xFFFF },
     { ACTOR_EN_ST,        {   572, 1393, 1456 }, { 0, 0xC000, 0 }, 0xFFFF },
     { ACTOR_OBJ_SYOKUDAI, { -1174, 1400, 1218 }, { 0,      0, 0 }, 0x27FF },
-    { ACTOR_OBJ_SYOKUDAI, {    16, 1360, 1299 }, { 0,      0, 0 }, 0x1087 },
+    { ACTOR_OBJ_SYOKUDAI, {    16, 1360, 1299 }, { 0,      0, 0 }, 0x1087 }, // Switch: 07
+    { ACTOR_OBJ_SYOKUDAI, {  1175, 1400, 964  }, { 0,      0, 0 }, 0x1087 }, // Switch: 07
     { ACTOR_EN_DEKUBABA,  {  -153, 1360, 1466 }, { 0,      0, 0 }, 0x0000 },
     { ACTOR_EN_DEKUBABA,  {   283, 1372, 1477 }, { 0,      0, 0 }, 0x0000 },
     { ACTOR_EN_DEKUBABA,  {  1036, 1400, 1038 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_OBJ_SYOKUDAI, {  1175, 1400, 964  }, { 0,      0, 0 }, 0x1087 },
 };
 
 RoomShapeCullable fairy_deku_tree_room_10MeshHeader0x0000D0 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_11.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_11.c
@@ -31,12 +31,12 @@ s16 fairy_deku_tree_room_11ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_11ActorList0x00004C[] = {
-    { ACTOR_EN_GOMA, 1431, 1400, 3, 0, 0, 0, 0x0007 },
-    { ACTOR_EN_GOMA, 1422, 1400, -73, 0, 0, 0, 0x0006 },
-    { ACTOR_EN_DEKUNUTS, 1004, 1400, -995, 0, 0, 0, 0x0000 },
-    { ACTOR_EN_DEKUNUTS, 1568, 1400, -569, 0, 0, 0, 0x0000 },
-    { ACTOR_EN_DEKUNUTS, 1298, 1400, -22, 0, 0, 0, 0x0000 },
-    { ACTOR_EN_DEKUNUTS, 1467, 1400, 462, 0, 0, 0, 0x0000 },
+    { ACTOR_EN_GOMA,     { 1431, 1400,    3 }, { 0, 0, 0 }, 0x0007 },
+    { ACTOR_EN_GOMA,     { 1422, 1400,  -73 }, { 0, 0, 0 }, 0x0006 },
+    { ACTOR_EN_DEKUNUTS, { 1004, 1400, -995 }, { 0, 0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUNUTS, { 1568, 1400, -569 }, { 0, 0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUNUTS, { 1298, 1400,  -22 }, { 0, 0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUNUTS, { 1467, 1400,  462 }, { 0, 0, 0 }, 0x0000 },
 };
 
 RoomShapeCullable fairy_deku_tree_room_11MeshHeader0x0000B0 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_12.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_12.c
@@ -38,7 +38,7 @@ ActorEntry fairy_deku_tree_room_12ActorList0x000048[] = {
     { ACTOR_EN_MINIBLIN, { 600, -640,  950 }, { 0,      0, 0 }, 0x0000 },
     { ACTOR_EN_MINIBLIN, { 350, -640, 1000 }, { 0, 0x4000, 0 }, 0x0000 },
     { ACTOR_EN_MINIBLIN, {  00, -640,  900 }, { 0,      0, 0 }, 0x0000 },
-    { ACTOR_OBJ_KIBAKO3, { 900, -280,  1050 }, { 0, 0x2000, 0 }, 0x0232 }, // Blue: 3 (Ancient Hollow & Forbidden Woods)
+    { ACTOR_OBJ_KIBAKO3, { 900, -280, 1050 }, { 0, 0x2000, 0 }, 0x0232 }, // Blue: 3 (Ancient Hollow & Forbidden Woods)
 };
 
 RoomShapeCullable fairy_deku_tree_room_12MeshHeader0x0000A0 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_2.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_2.c
@@ -31,11 +31,11 @@ s16 fairy_deku_tree_room_2ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_2ActorList0x000048[] = {
-    { ACTOR_EN_ST, -135, 506, 146, 0, -8192, 0, 0xFFFF },
-    { ACTOR_EN_ST, 75, 494, -70, 0, -8192, 0, 0xFFFF },
-    { ACTOR_EN_DEKUNUTS, -195, 320, -175, 0, 0, 0, 0x0000 },
-    { ACTOR_EN_DEKUNUTS, 110, 320, 98, 0, 0, 0, 0x0000 },
-    { ACTOR_EN_TP, -11, 333, 0, 0, 0, 0, 0xFFFE },
+    { ACTOR_EN_ST,       { -135, 506,  146 }, { 0, 0xE000, 0 }, 0xFFFF },
+    { ACTOR_EN_ST,       {   75, 494,  -70 }, { 0, 0xE000, 0 }, 0xFFFF },
+    { ACTOR_EN_DEKUNUTS, { -195, 320, -175 }, { 0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_DEKUNUTS, {  110, 320,   98 }, { 0,      0, 0 }, 0x0000 },
+    { ACTOR_EN_TP,       {  -11, 333,    0 }, { 0,      0, 0 }, 0xFFFE },
 };
 
 RoomShapeCullable fairy_deku_tree_room_2MeshHeader0x0000A0 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_3.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_3.c
@@ -31,16 +31,16 @@ s16 fairy_deku_tree_room_3ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_3ActorList0x00004C[] = {
-    { ACTOR_OBJ_SWITCH, {  284, 906, -280 }, { 0, 0xE000, 0 }, 0x0102 },
-    { ACTOR_EN_BOX,     { -190, 720, -211 }, { 0, 0xA001, 0 }, 0x5D22 },
-    { ACTOR_EN_GOMA,    {   -5, 720,  -99 }, { 0,      0, 0 }, 0x0006 },
-    { ACTOR_EN_GOMA,    {   -5, 720,   56 }, { 0,      0, 0 }, 0x0006 },
-    { ACTOR_EN_GOMA,    {   71, 720,  -20 }, { 0,      0, 0 }, 0x0006 },
-    { ACTOR_EN_GOMA,    {  -84, 720,  -18 }, { 0,      0, 0 }, 0x0006 },
-    { ACTOR_EN_GOMA,    { -137, 720,  107 }, { 0,      0, 0 }, 0x0007 },
-    { ACTOR_EN_GOMA,    { -129, 720, -138 }, { 0,      0, 0 }, 0x0007 },
-    { ACTOR_EN_GOMA,    {  135, 720, -130 }, { 0,      0, 0 }, 0x0007 },
-    { ACTOR_EN_GOMA,    {  135, 720,  101 }, { 0,      0, 0 }, 0x0007 },
+    { ACTOR_OBJ_SWITCH, {  284, 906, -280 }, {    0, 0xE000, 0 }, 0x0102 }, // Switch: 01
+    { ACTOR_EN_BOX,     { -190, 720, -211 }, { 0x69, 0xA000, 0 }, 0x5002 }, // Chest: 02, Deku Seeds
+    { ACTOR_EN_GOMA,    {   -5, 720,  -99 }, {    0,      0, 0 }, 0x0006 },
+    { ACTOR_EN_GOMA,    {   -5, 720,   56 }, {    0,      0, 0 }, 0x0006 },
+    { ACTOR_EN_GOMA,    {   71, 720,  -20 }, {    0,      0, 0 }, 0x0006 },
+    { ACTOR_EN_GOMA,    {  -84, 720,  -18 }, {    0,      0, 0 }, 0x0006 },
+    { ACTOR_EN_GOMA,    { -137, 720,  107 }, {    0,      0, 0 }, 0x0007 },
+    { ACTOR_EN_GOMA,    { -129, 720, -138 }, {    0,      0, 0 }, 0x0007 },
+    { ACTOR_EN_GOMA,    {  135, 720, -130 }, {    0,      0, 0 }, 0x0007 },
+    { ACTOR_EN_GOMA,    {  135, 720,  101 }, {    0,      0, 0 }, 0x0007 },
 };
 
 RoomShapeCullable fairy_deku_tree_room_3MeshHeader0x0000F0 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_4.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_4.c
@@ -32,9 +32,9 @@ s16 fairy_deku_tree_room_4ObjectList0x000038[] = {
 
 ActorEntry fairy_deku_tree_room_4ActorList0x000048[] = {
     { ACTOR_OBJ_SYOKUDAI, {   -1, 1000,   -6 }, { 0, 0, 0 }, 0x27FF },
-    { ACTOR_OBJ_SYOKUDAI, {   -1, 1000, -152 }, { 0, 0, 0 }, 0x10C6 },
-    { ACTOR_OBJ_SYOKUDAI, {  121, 1000,  104 }, { 0, 0, 0 }, 0x10C6 },
-    { ACTOR_OBJ_SYOKUDAI, { -123, 1000,  104 }, { 0, 0, 0 }, 0x10C6 },
+    { ACTOR_OBJ_SYOKUDAI, {   -1, 1000, -152 }, { 0, 0, 0 }, 0x10C6 }, // Switch: 06
+    { ACTOR_OBJ_SYOKUDAI, {  121, 1000,  104 }, { 0, 0, 0 }, 0x10C6 }, // Switch: 06
+    { ACTOR_OBJ_SYOKUDAI, { -123, 1000,  104 }, { 0, 0, 0 }, 0x10C6 }, // Switch: 06
     { ACTOR_EN_DEKUBABA,  { -266, 1000,  -72 }, { 0, 0, 0 }, 0x0001 },
     { ACTOR_EN_DEKUBABA,  {   -7, 1000,  301 }, { 0, 0, 0 }, 0x0001 },
     { ACTOR_EN_DEKUBABA,  {   22, 1000, -340 }, { 0, 0, 0 }, 0x0000 },

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_5.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_5.c
@@ -31,9 +31,9 @@ s16 fairy_deku_tree_room_5ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_5ActorList0x00004C[] = {
-    { ACTOR_EN_DEKUBABA, 13, 1320, -158, 0, 0, 0, 0x0001 },
-    { ACTOR_EN_DEKUBABA, -149, 1320, 10, 0, 0, 0, 0x0001 },
-    { ACTOR_EN_DEKUBABA, 82, 1320, 59, 0, 0, 0, 0x0001 },
+    { ACTOR_EN_DEKUBABA, {   13, 1320, -158 }, { 0, 0, 0 }, 0x0001 },
+    { ACTOR_EN_DEKUBABA, { -149, 1320,   10 }, { 0, 0, 0 }, 0x0001 },
+    { ACTOR_EN_DEKUBABA, {   82, 1320,   59 }, { 0, 0, 0 }, 0x0001 },
 };
 
 RoomShapeCullable fairy_deku_tree_room_5MeshHeader0x000080 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_6.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_6.c
@@ -32,18 +32,18 @@ s16 fairy_deku_tree_room_6ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_6ActorList0x000048[] = {
-    { ACTOR_OBJ_SWITCH,      { 1583, 160,  -248 }, { 0, 0x1555,    0 }, 0x2000 },
-    { ACTOR_OBJ_SWITCH,      { 1238, 350, -1235 }, { 0, 0xE000,    0 }, 0x1F02 },
-    { ACTOR_EN_BOX,          { 1113, 200, -1178 }, { 0, 0x5FFF, 0x1F }, 0x8843 },
-    { ACTOR_EN_DEKUBABA,     { 1392, 160,  -131 }, { 0,      0,    0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,     { 1395, 160,  -309 }, { 0,      0,    0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,     {  480, 240, -1429 }, { 0,      0,    0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,     {   72, 240, -1508 }, { 0,      0,    0 }, 0x0000 },
-    { ACTOR_EN_BOX,          {   65, 240, -1645 }, { 0, 0x7FFF,    0 }, 0x50E4 },
-    { ACTOR_EN_DEKUBABA,     {  196, 240, -1580 }, { 0,      0,    0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,     {  291, 240, -1684 }, { 0,      0,    0 }, 0x0000 },
-    { ACTOR_EN_DEKUBABA,     {  420, 240, -1286 }, { 0,      0,    0 }, 0x0000 },
-    { ACTOR_BG_YDAN_MARUTA2, { 1141,  80, -1078 }, { 0, 0x905C,    0 }, 0x0020 },
+    { ACTOR_OBJ_SWITCH,      { 1583, 160,  -248 }, {    0, 0x1555,    0 }, 0x2000 }, // Switch: 20
+    { ACTOR_OBJ_SWITCH,      { 1238, 350, -1235 }, {    0, 0xE000,    0 }, 0x1F02 }, // Switch: 1F
+    { ACTOR_EN_BOX,          { 1113, 200, -1178 }, { 0x42, 0x6000, 0x1F }, 0x8003 }, // Chest: 03, checks switch: 1F, Small Key
+    { ACTOR_EN_BOX,          {   65, 240, -1645 }, {  0x7, 0x8000,    0 }, 0x5004 }, // Chest: 04, Deku Stick
+    { ACTOR_EN_DEKUBABA,     { 1392, 160,  -131 }, {    0,      0,    0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,     { 1395, 160,  -309 }, {    0,      0,    0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,     {  480, 240, -1429 }, {    0,      0,    0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,     {   72, 240, -1508 }, {    0,      0,    0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,     {  196, 240, -1580 }, {    0,      0,    0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,     {  291, 240, -1684 }, {    0,      0,    0 }, 0x0000 },
+    { ACTOR_EN_DEKUBABA,     {  420, 240, -1286 }, {    0,      0,    0 }, 0x0000 },
+    { ACTOR_BG_YDAN_MARUTA2, { 1141,  80, -1078 }, {    0, 0x905C,    0 }, 0x0020 }, // Switch: 20
 };
 
 RoomShapeCullable fairy_deku_tree_room_6MeshHeader0x000100 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_7.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_7.c
@@ -32,8 +32,8 @@ s16 fairy_deku_tree_room_7ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_7ActorList0x000048[] = {
-    { ACTOR_EN_BOX,  { -953, 520,  950 }, { 0, 0xE000, 0 }, 0x1825 },
-    { ACTOR_EN_TEST, { -860, 520, 1080 }, { 0, 0xE000, 0 }, 0x0003 },
+    { ACTOR_EN_BOX,  { -953, 520,  950 }, { 0x41, 0xE000, 0 }, 0x1005 }, // Chest: 05, appears on clear, Dungeon Map
+    { ACTOR_EN_TEST, { -860, 520, 1080 }, {    0, 0xE000, 0 }, 0x0003 },
 };
 
 RoomShapeCullable fairy_deku_tree_room_7MeshHeader0x000060 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_8.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_8.c
@@ -32,8 +32,8 @@ s16 fairy_deku_tree_room_8ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_8ActorList0x000048[] = {
-    { ACTOR_EN_BOX,   { 2001, 760, -9 }, { 0, 0x4000, 0x1D }, 0x1806 },
-    { ACTOR_EN_BEAST, { 1900, 760,  0 }, { 0, 0x4000,    0 }, 0xFF00 },
+    { ACTOR_EN_BOX,   { 2001, 760, -9 }, { 0x40, 0x4000, 0 }, 0x1006 }, // Chest: 06, appears on clear, Compass
+    { ACTOR_EN_BEAST, { 1900, 760,  0 }, {    0, 0x4000, 0 }, 0xFF00 },
 };
 
 RoomShapeCullable fairy_deku_tree_room_8MeshHeader0x000060 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_9.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_9.c
@@ -31,15 +31,15 @@ s16 fairy_deku_tree_room_9ObjectList0x000038[] = {
 };
 
 ActorEntry fairy_deku_tree_room_9ActorList0x000048[] = {
+    { ACTOR_OBJ_SWITCH,  { 1135, 1160, -1158 }, { 0, 0x2000, 0 }, 0x0400 }, // Switch: 04
+    { ACTOR_EN_ITEM00,   { 1522,  960,  -227 }, { 0,      0, 0 }, 0x2103 }, // Collectible: 21, Red Rupee
+    { ACTOR_OBJ_KIBAKO3, { 1150,  960, -1250 }, { 0, 0x2000, 0 }, 0x0242 }, // Blue: 4 (Ancient Hollow & Forbidden Woods)
     { ACTOR_EN_TP,       { 1362, 1173,  -987 }, { 0,      0, 0 }, 0xFFFE },
-    { ACTOR_OBJ_SWITCH,  { 1135, 1160, -1158 }, { 0, 0x2000, 0 }, 0x0400 },
     { ACTOR_EN_TP,       { 1131,  997,  -802 }, { 0,      0, 0 }, 0xFFFE },
     { ACTOR_EN_ST,       { 1502, 1162,   297 }, { 0,      0, 0 }, 0xFFFF },
     { ACTOR_EN_ST,       { 1508, 1162,  -298 }, { 0,      0, 0 }, 0x0009 },
     { ACTOR_EN_ST,       { 1087, 1059,   864 }, { 0,      0, 0 }, 0xFFFF },
     { ACTOR_EN_DEKUBABA, { 1407,  960,    16 }, { 0,      0, 0 }, 0x0001 },
-    { ACTOR_EN_ITEM00,   { 1522,  960,  -227 }, { 0,      0, 0 }, 0x0003 },
-    { ACTOR_OBJ_KIBAKO3, { 1150,  960, -1250 }, { 0, 0x2000, 0 }, 0x0242 }, // Blue: 4 (Ancient Hollow & Forbidden Woods)
 };
 
 RoomShapeCullable fairy_deku_tree_room_9MeshHeader0x0000D0 = {

--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_scene.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_scene.c
@@ -45,30 +45,30 @@ ActorEntry fairy_deku_tree_sceneStartPositionList0x000058[] = {
 };
 
 TransitionActorEntry fairy_deku_tree_sceneTransitionActorList0x000078[] = {
-    { 12, 255,  0, 255, ACTOR_DOOR_SHUTTER,  798,  200,   798, 0xA001, 0x02DD },
-    {  0, 255, 11, 255, ACTOR_DOOR_SHUTTER,  798, 1480,  -798, 0x5FFF, 0x007F },
-    {  0,   6,  4, 255, ACTOR_DOOR_SHUTTER,  299, 1080,   299, 0xA001, 0x0086 },
-    {  0,   7,  5, 255, ACTOR_DOOR_SHUTTER,  299, 1400,   299, 0xA001, 0x007F },
-    { 11, 255, 10, 255, ACTOR_DOOR_SHUTTER, 1375, 1400,   702, 0xE000, 0x0087 },
-    {  9, 255,  9, 255, ACTOR_DOOR_SHUTTER, 1439,  960,  -618, 0x105B, 0x003F },
-    {  0, 255, 10, 255, ACTOR_DOOR_SHUTTER,  798, 1400,   798, 0x2001, 0x009E },
-    { 13, 255, 12, 255, ACTOR_DOOR_SHUTTER,  344, -640,   831, 0x105B, 0x015C },
-    {  5, 255,  0,   9, ACTOR_DOOR_SHUTTER,  299, 1480,  -299, 0x5FFF, 0x003F },
-    {  2, 255,  0,  10, ACTOR_DOOR_SHUTTER,  299,  520,  -299, 0x5FFF, 0x003F },
-    {  2, 255,  0,   1, ACTOR_DOOR_SHUTTER, -299,  520,   299, 0xE000, 0x003F },
-    {  3, 255,  0,   4, ACTOR_DOOR_SHUTTER,    0,  720,   423, 0x0000, 0x003F },
-    { 10, 255,  0, 255, ACTOR_DOOR_SHUTTER, -798, 1320,   798, 0x5FFF, 0x003F },
-    {  6, 255,  0, 255, ACTOR_DOOR_SHUTTER,   -1,  240, -1129, 0x0000, 0x003F },
-    {  6, 255,  0, 255, ACTOR_DOOR_SHUTTER, 1129,  160,     0, 0xC000, 0x003F },
-    {  0, 255,  9, 255, ACTOR_DOOR_SHUTTER,  798, 1160,  -798, 0x5FFF, 0x0084 },
-    {  2, 255,  0,   3, ACTOR_DOOR_SHUTTER,    0,  400,   423, 0x0000, 0x003F },
-    {  1, 255,  0, 255, ACTOR_DOOR_SHUTTER,    0,    0,  -643, 0x7FFF, 0x003F },
-    {  0,   2,  1, 255, ACTOR_DOOR_SHUTTER,    0,   80,   423, 0x7FFF, 0x0088 },
-    {  0,   8,  3, 255, ACTOR_DOOR_SHUTTER,  299,  720,  -299, 0xE000, 0x0081 },
-    {  4, 255,  0,   5, ACTOR_DOOR_SHUTTER, -299, 1000,   299, 0xE000, 0x0082 },
-    {  9, 255,  0, 255, ACTOR_DOOR_SHUTTER,  798, 1080,   798, 0xA001, 0x0083 },
-    {  8, 255,  0, 255, ACTOR_DOOR_SHUTTER, 1129,  760,     0, 0xC000, 0x01C5 },
-    {  7, 255,  0, 255, ACTOR_DOOR_SHUTTER, -799,  520,   798, 0x5FFF, 0x01C0 },
+    { 12, -3,  0, -3, ACTOR_DOOR_SHUTTER, {  798,  200,   798 }, 0xA000, 0x02DD }, // 0, Sets switch: 1D
+    {  0, -3, 11, -3, ACTOR_DOOR_SHUTTER, {  798, 1480,  -798 }, 0x6000, 0x007F }, // 1
+    {  0,  6,  4, -3, ACTOR_DOOR_SHUTTER, {  299, 1080,   299 }, 0xA000, 0x0086 }, // 2, Checks switch: 06
+    {  0,  7,  5, -3, ACTOR_DOOR_SHUTTER, {  299, 1400,   299 }, 0xA000, 0x007F }, // 3
+    { 11, -3, 10, -3, ACTOR_DOOR_SHUTTER, { 1375, 1400,   702 }, 0xE000, 0x0087 }, // 4, Checks switch: 07
+    {  9, -3,  9, -3, ACTOR_DOOR_SHUTTER, { 1439,  960,  -618 }, 0x105B, 0x003F }, // 5
+    {  0, -3, 10, -3, ACTOR_DOOR_SHUTTER, {  798, 1400,   798 }, 0x2000, 0x009E }, // 6, Checks switch: 1E
+    { 13, -3, 12, -1, ACTOR_DOOR_SHUTTER, {  344, -640,   831 }, 0x105B, 0x015C }, // 7, Sets switch: 1C
+    {  5, -3,  0,  9, ACTOR_DOOR_SHUTTER, {  299, 1480,  -299 }, 0x6000, 0x003F }, // 8
+    {  2, -3,  0, 10, ACTOR_DOOR_SHUTTER, {  299,  520,  -299 }, 0x6000, 0x003F }, // 9
+    {  2, -3,  0,  1, ACTOR_DOOR_SHUTTER, { -299,  520,   299 }, 0xE000, 0x003F }, // 10
+    {  3, -3,  0,  4, ACTOR_DOOR_SHUTTER, {    0,  720,   423 }, 0x0000, 0x003F }, // 11
+    { 10, -3,  0, -3, ACTOR_DOOR_SHUTTER, { -798, 1320,   798 }, 0x6000, 0x003F }, // 12
+    {  6, -3,  0, -3, ACTOR_DOOR_SHUTTER, {   -1,  240, -1129 }, 0x0000, 0x003F }, // 13
+    {  6, -3,  0, -3, ACTOR_DOOR_SHUTTER, { 1129,  160,     0 }, 0xC000, 0x003F }, // 14
+    {  0, -3,  9, -3, ACTOR_DOOR_SHUTTER, {  798, 1160,  -798 }, 0x6000, 0x0084 }, // 15, Checks switch: 04
+    {  2, -3,  0,  3, ACTOR_DOOR_SHUTTER, {    0,  400,   423 }, 0x0000, 0x003F }, // 16
+    {  1, -3,  0, -3, ACTOR_DOOR_SHUTTER, {    0,    0,  -643 }, 0x8000, 0x003F }, // 17
+    {  0,  2,  1, -3, ACTOR_DOOR_SHUTTER, {    0,   80,   423 }, 0x8000, 0x0088 }, // 18, Checks switch: 08
+    {  0,  8,  3, -3, ACTOR_DOOR_SHUTTER, {  299,  720,  -299 }, 0xE000, 0x0081 }, // 19, Checks switch: 01
+    {  4, -3,  0,  5, ACTOR_DOOR_SHUTTER, { -299, 1000,   299 }, 0xE000, 0x0082 }, // 20, Checks switch: 02
+    {  9, -3,  0, -3, ACTOR_DOOR_SHUTTER, {  798, 1080,   798 }, 0xA000, 0x0083 }, // 21, Checks switch: 03
+    {  8, -3,  0, -3, ACTOR_DOOR_SHUTTER, { 1129,  760,     0 }, 0xC000, 0x01C5 }, // 22, Checks switch: 05
+    {  7, -3,  0, -3, ACTOR_DOOR_SHUTTER, { -799,  520,   798 }, 0x6000, 0x01C0 }, // 23
 };
 
 RomFile fairy_deku_tree_sceneRoomList0x0001F8[] = {
@@ -121,70 +121,906 @@ EnvLightSettings fairy_deku_tree_sceneLightSettings0x000270[] = {
 };
 
 Vec3s fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[] = {
-    {     -1,     54,   1058 },
-    {      0,  -1092,      0 },
-    {     -1,      0,      0 },
-    {   -548,    579,    470 },
-    {    364,  20024,      0 },
-    {     -1,      0,      0 },
-    {    -84,    141,    655 },
-    {   -364,  28580,      0 },
-    {     -1,      0,      0 },
-    {    -79,    502,    659 },
-    {   2367,  28034,      0 },
-    {     -1,      0,      0 },
-    {    -82,    855,    660 },
-    {   4369,  28944,      0 },
-    {     -1,      0,      0 },
-    {   -496,   1071,    361 },
-    {   1820,  18386,      0 },
-    {     -1,      0,      0 },
-    {    407,   1170,    540 },
-    {   2002, -29490,      0 },
-    {     -1,      0,      0 },
-    {    473,   1477,    545 },
-    {   1274, -26942,      0 },
-    {     -1,      0,      0 },
-    {    519,    811,   -401 },
-    {   1274, -12197,      0 },
-    {     -1,      0,      0 },
-    {    519,   1571,   -395 },
-    {   1638, -12561,      0 },
-    {     -1,      0,      0 },
-    {    519,    607,   -392 },
-    {   2002, -12561,      0 },
-    {     -1,      0,      0 },
-    {      0,   2847,     10 },
-    {      0,      0,      0 },
-    {     -1,      0,      0 },
+    {   -1,     54, 1058 }, // Cam ID: 0 (spawn)
+    {    0,  -1092,    0 },
+    {   -1,      0,    0 },
+    { -548,    579,  470 }, // Cam ID: 1 (back door)
+    {  364,  20024,    0 },
+    {   -1,      0,    0 },
+    {  -84,    141,  655 }, // Cam ID: 2 (front door)
+    { -364,  28580,    0 },
+    {   -1,      0,    0 }, 
+    {  -79,    502,  659 }, // Cam ID: 3 (back door)
+    { 2367,  28034,    0 },
+    {   -1,      0,    0 },
+    {  -82,    855,  660 }, // Cam ID: 4 (back door)
+    { 4369,  28944,    0 },
+    {   -1,      0,    0 },
+    { -496,   1071,  361 }, // Cam ID: 5 (back door)
+    { 1820,  18386,    0 },
+    {   -1,      0,    0 },
+    {  407,   1170,  540 }, // Cam ID: 6 (front door)
+    { 2002, -29490,    0 },
+    {   -1,      0,    0 },
+    {  473,   1477,  545 }, // Cam ID: 7 (front door)
+    { 1274, -26942,    0 },
+    {   -1,      0,    0 },
+    {    519,  811, -401 }, // Cam ID: 8 (front door)
+    { 1274, -12197,    0 },
+    {   -1,      0,    0 },
+    {  519,   1571, -395 }, // Cam ID: 9 (back door)
+    { 1638, -12561,    0 },
+    {   -1,      0,    0 },
+    {  519,    607, -392 }, // Cam ID: 10 (back door)
+    { 2002, -12561,    0 },
+    {   -1,      0,    0 },
+    {    0,   2847,   10 }, // Cam ID: 11 (spiral)
+    {    0,      0,    0 },
+    {   -1,      0,    0 },
 };
 
 BgCamInfo fairy_deku_tree_sceneCollisionHeader0x00EA9C_camDataList_000003D8[] = {
-    /* spawn      */ { CAM_SET_SCENE_UNUSED,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* back door  */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* front door */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* back door  */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* back door  */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* back door  */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* front door */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* front door */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* front door */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* back door  */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* back door  */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* spiral     */ { CAM_SET_DUNGEON0,            3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0] },
-    /* keep cam   */ { CAM_SET_NONE,                0, NULL },
-                     { CAM_SET_BOSS_MORPHA,         0, NULL },
-                     { CAM_SET_NORMAL0,             0, NULL },
-                     { CAM_SET_DUNGEON0,            0, NULL }, // Top central pillar room (Babas & torches room) cam, torch puzzle & Skulltula room cam
-                     { CAM_SET_BOSS_TWINROVA_FLOOR, 0, NULL },
-                     { CAM_SET_NORMAL3,             0, NULL },
+    /* spawn      */ { CAM_SET_SCENE_UNUSED, 3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[0]  },
+    /* back door  */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[3]  },
+    /* front door */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[6]  },
+    /* back door  */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[9]  },
+    /* back door  */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[12] },
+    /* back door  */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[15] },
+    /* front door */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[18] },
+    /* front door */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[21] },
+    /* front door */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[24] },
+    /* back door  */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[27] },
+    /* back door  */ { CAM_SET_DOOR0,        3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[30] },
+    /* spiral     */ { CAM_SET_TOWER0,       3, &fairy_deku_tree_sceneCollisionHeader0x00EA9C_camPosData_00000300[33] },
+    /* keep cam   */ { CAM_SET_NONE,         0, NULL },
+                     { CAM_SET_BRIDGE,       0, NULL },
+                     { CAM_SET_NORMAL0,      0, NULL },
+                     { CAM_SET_DUNGEON0,     0, NULL }, // Top central pillar room (Babas & torches room) cam, torch puzzle & Skulltula room cam
+                     { CAM_SET_STAIRS,       0, NULL },
+                     { CAM_SET_NORMAL3,      0, NULL },
 };
 
 SurfaceType fairy_deku_tree_sceneCollisionHeader0x00EA9C_polygonTypes_00000468[] = {
-   { 0x0000000C, 0x00000000 }, { 0x0000000B, 0x0000000A }, { 0x0000000D, 0x00000009 }, { 0x0000000B, 0x00000000 }, { 0x0000000C, 0x0000000A }, { 0x0000000C, 0x00000009 }, { 0x0000000E, 0x00000000 }, { 0x0000000E, 0x00000009 }, { 0x0000000E, 0x00000140 }, { 0x0000010E, 0x00000140 },
-   { 0x0060000C, 0x00000000 }, { 0x0040000C, 0x00000000 }, { 0x0000000C, 0x00000040 }, { 0x0000000C, 0x0000004A }, { 0x0000000E, 0x0000004A }, { 0x0000000D, 0x00000049 }, { 0x0000000D, 0x0000004A }, { 0x0000000E, 0x00000040 }, { 0x0000000F, 0x0000004A }, { 0x0000000C, 0x00000080 },
-   { 0x0000000C, 0x0000008A }, { 0x0000000E, 0x00000080 }, { 0x00000010, 0x00000080 }, { 0x0000000F, 0x0000008A }, { 0x0000000E, 0x0000008A }, { 0x0000000F, 0x00000080 }, { 0x0040000C, 0x00000080 }, { 0x0060000C, 0x00000080 }, { 0x0000000F, 0x0000000A }, { 0x0000000E, 0x0000000A },
-   { 0x0040000C, 0x00000040 }, { 0x0060000C, 0x00000040 }, { 0x0000000C, 0x000000C0 }, { 0x0000000E, 0x000000C0 }, { 0x00000011, 0x000000C0 },
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 0
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 11,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 1
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 13,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_BRIDGE,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 2
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 11,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 3
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 4
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_BRIDGE,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 5
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 6
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_BRIDGE,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 7
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 5,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 8
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 1,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 5,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 9
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_3,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 10
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_2,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 11
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 12
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 13
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 14
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 13,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_BRIDGE,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 15
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 13,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 16
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 17
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 15,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 18
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 19
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 20
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 21
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 16,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 22
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 15,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 23
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 24
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 15,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 25
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_2,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 26
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_3,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 2,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 27
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 15,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 28
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 0,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 29
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_2,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 30
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_3,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 1,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 31
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 12,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 3,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 32
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 14,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 3,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 33
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 17,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 3,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 34
 };
 
 CollisionPoly fairy_deku_tree_sceneCollisionHeader0x00EA9C_polygons_00000580[2892] = {

--- a/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_scene.c
+++ b/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_scene.c
@@ -152,15 +152,15 @@ Path old_dodongos_cavern_scenePathway[] = {
 };
 
 BgCamInfo old_dodongos_cavern_sceneCollisionHeader0x00E38C_camDataList_00000264[] = {
-	{ CAM_SET_DUNGEON0,               0, NULL }, // Entrance cam
-	{ CAM_SET_NONE,                   0, NULL }, // "Keep current camera"
-	{ CAM_SET_BOSS_MORPHA,            0, NULL }, // Hanging wooden bridges cam
-	{ CAM_SET_NORMAL0,                0, NULL }, // Main room cam, Keese tunnel near heart cam, Lizalfos room cam, boss room upper cam
-	{ CAM_SET_NORMAL3,                0, NULL }, // Blue Dodongo room cam near door and near vine area, tunnel to stair room cam
-	{ CAM_SET_BOSS_TWINROVA_PLATFORM, 0, NULL }, // Tunnel cam
-	{ CAM_SET_DUNGEON0,               0, NULL }, // Stair room cam
-	{ CAM_SET_BOSS_BONGO,             0, NULL }, // Lizalfos room lava cam
-	{ CAM_SET_DUNGEON2,               0, NULL }, // Boss cam
+	{ CAM_SET_DUNGEON0, 0, NULL }, // Entrance cam
+	{ CAM_SET_NONE,     0, NULL }, // "Keep current camera"
+	{ CAM_SET_BRIDGE,   0, NULL }, // Hanging wooden bridges cam
+	{ CAM_SET_NORMAL0,  0, NULL }, // Main room cam, Keese tunnel near heart cam, Lizalfos room cam, boss room upper cam
+	{ CAM_SET_NORMAL3,  0, NULL }, // Blue Dodongo room cam near door and near vine area, tunnel to stair room cam
+	{ CAM_SET_TUNNEL,   0, NULL }, // Tunnel cam
+	{ CAM_SET_DUNGEON0, 0, NULL }, // Stair room cam
+	{ CAM_SET_LOOKUP,   0, NULL }, // Lizalfos room lava cam
+	{ CAM_SET_DUNGEON2, 0, NULL }, // Boss cam
 };
 
 SurfaceType old_dodongos_cavern_sceneCollisionHeader0x00E38C_polygonTypes_000002AC[] = {

--- a/assets/scenes/misc/grottos2/grottos2_room_10.c
+++ b/assets/scenes/misc/grottos2/grottos2_room_10.c
@@ -23,8 +23,8 @@ s16 grottos2_room_10ObjectList_000040[] = {
 };
 
 ActorEntry grottos2_room_10ActorEntry_000048[] = {
-    { ACTOR_EN_STALM, { 2400, 0, 900 }, {    0, 0x8000, 0 }, 0x0101 }, // Switch: 01
-    { ACTOR_EN_BOX,   { 2400, 0, 700 }, { 0x3E, 0x8000, 1 }, 0xB000 },
+    { ACTOR_EN_STALM, { 2400, 0, 900 }, {    0, 0x8000, 0 }, 0x0001 }, // Switch: 00
+    { ACTOR_EN_BOX,   { 2400, 0, 700 }, { 0x3E, 0x8000, 0 }, 0xB000 }, // Chest flag: 00, checks switch: 00, Piece of Heart
 };
 
 RoomShapeCullable grottos2_room_10RoomShapeCullable_000100 = { 

--- a/assets/scenes/misc/grottos2/grottos2_room_13.c
+++ b/assets/scenes/misc/grottos2/grottos2_room_13.c
@@ -23,8 +23,8 @@ s16 grottos2_room_13ObjectList_000040[] = {
 };
 
 ActorEntry grottos2_room_13ActorEntry_000048[] = {
-    { ACTOR_EN_STALM, { 5200, -20, 600 }, {    0, 0x8000, 0 }, 0x0001 }, // Switch: 00
-    { ACTOR_EN_BOX,   { 5200, -20, 100 }, { 0x3E, 0x8000, 0 }, 0xB000 },
+    { ACTOR_EN_STALM, { 5200, -20, 600 }, {    0, 0x8000, 0 }, 0x0101 }, // Switch: 01
+    { ACTOR_EN_BOX,   { 5200, -20, 100 }, { 0x3E, 0x8000, 1 }, 0xB001 }, // Chest flag: 01, checks switch: 01, Piece of Heart
 };
 
 RoomShapeCullable grottos2_room_13RoomShapeCullable_000090 = { 

--- a/assets/scenes/misc/grottos2/grottos2_room_7.c
+++ b/assets/scenes/misc/grottos2/grottos2_room_7.c
@@ -23,9 +23,9 @@ s16 grottos2_room_7ObjectList_000040[] = {
 };
 
 ActorEntry grottos2_room_7ActorEntry_000048[] = {
-    { ACTOR_EN_DINOFOS, { 513, 0, 1019 }, { 0,         0, 0 }, 0x0000 },
-    { ACTOR_EN_DINOFOS, { 741, 0,  858 }, { 0,         0, 0 }, 0x0000 },
-    { ACTOR_EN_BOX,     { 615, 0,  786 }, { 0x3E, 0x8000, 0 }, 0x1000 },
+    { ACTOR_EN_DINOFOS, { 513, 0, 1019 }, { 0,         0, 0 }, 0xFE00 },
+    { ACTOR_EN_DINOFOS, { 741, 0,  858 }, { 0,         0, 0 }, 0xFE00 },
+    { ACTOR_EN_BOX,     { 615, 0,  786 }, { 0x3E, 0x8000, 0 }, 0x1002 }, // Chest flag: 02, appears on room clear, Piece of Heart
 };
 
 RoomShapeCullable grottos2_room_7RoomShapeCullable_000080 = { 

--- a/assets/scenes/overworld/old_lost_woods/old_lost_woods_scene.c
+++ b/assets/scenes/overworld/old_lost_woods/old_lost_woods_scene.c
@@ -63,23 +63,350 @@ EnvLightSettings old_lost_woods_sceneLightSettings0x0000C0[] = {
 	{ { 0x50, 0x50, 0x50 }, { 0x49, 0x49, 0x49 }, { 0xC8, 0xC8, 0xC8 }, { 0xB7, 0xB7, 0xB7 }, { 0x32, 0x32, 0x6E }, { 0x32, 0x32, 0x3C }, ((0 / 4) << 10) | 920,  1800 }, // Original fog near: 970, old: 842
 };
 
-Vec3s old_lost_woods_sceneCollisionHeader0x0068D4_camPosData_00000130[3] = {
-    {   1682,    300,    568 },
-    {   8010, -18022,      0 },
-    {     -1,      0,      0 },
-};
-
 BgCamInfo old_lost_woods_sceneCollisionHeader0x0068D4_camDataList_00000144[] = {
-    { CAM_SET_DOORC,   3, &old_lost_woods_sceneCollisionHeader0x0068D4_camPosData_00000130[0] },
     { CAM_SET_NONE,    0, NULL },
     { CAM_SET_NORMAL4, 0, NULL }, // Used inside of log tunnels
     { CAM_SET_NORMAL0, 0, NULL },
-    { CAM_SET_NORMAL0, 0, NULL }, // Sloped tall grass under sloped tree trunk cam
+    { CAM_SET_LOOKUP,  0, NULL }, // Sloped tall grass under sloped tree trunk cam
 };
 
 SurfaceType old_lost_woods_sceneCollisionHeader0x0068D4_polygonTypes_0000016C[] = {
-   0x00000001, 0x00000100, 0x00000001, 0x0000010A, 0x00000002, 0x0000010A, 0x00000401, 0x0000010A, 0x00000402, 0x0000010A, 0x00000003, 0x00000100, 0x00000201, 0x00000100, 0x00000101, 0x00000100, 0x00000002, 0x00000100, 0x00000004, 0x00000100, 0x00000502, 0x0000010A, 0x00000501, 0x0000010A,
-   0x00000003, 0x0000010A, 0x00000301, 0x0000010A,
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 0,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 0
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 0,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 1
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 1,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 2
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 0,
+                /* exitIndex */ 4,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 3
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 1,
+                /* exitIndex */ 4,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 4
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 2,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 5
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 0,
+                /* exitIndex */ 2,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 6
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 0,
+                /* exitIndex */ 1,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 7
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 1,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 8
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 3,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_DIRT,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 9
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 1,
+                /* exitIndex */ 5,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 10
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 0,
+                /* exitIndex */ 5,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 11
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 2,
+                /* exitIndex */ 0,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 12
+    {
+        {
+            SURFACETYPE0(
+                /* bgCamIndex */ 0,
+                /* exitIndex */ 3,
+                FLOOR_TYPE_0,
+                /* unk18 */ 0,
+                WALL_TYPE_0,
+                FLOOR_PROPERTY_0,
+                /* isSoft */ false,
+                /* isHorseBlocked */ false
+            ),
+            SURFACETYPE1(
+                SURFACE_MATERIAL_WOOD,
+                FLOOR_EFFECT_0,
+                /* lightSetting */ 4,
+                /* echo */ 0,
+                /* canHookshot */ false,
+                CONVEYOR_SPEED_DISABLED,
+                CONVEYOR_DIRECTION_FROM_BINANG(0x0),
+                /* unk27 */ false
+            ),
+        },
+    }, // 13
 };
 
 CollisionPoly old_lost_woods_sceneCollisionHeader0x0068D4_polygons_000001DC[1368] = {

--- a/include/camera.h
+++ b/include/camera.h
@@ -208,9 +208,15 @@ typedef enum CameraSettingType {
     /* 0x3F */ CAM_SET_DIRECTED_YAW, // Does not auto-update yaw, tends to keep the camera pointed at a certain yaw (used by biggoron and final spirit lowering platform) "TEPPEN"
     /* 0x40 */ CAM_SET_PIVOT_FROM_SIDE, // Fixed side view, allows rotation of camera (eg. Potion Shop, Meadow at fairy grotto) "CIRCLE7"
     /* 0x41 */ CAM_SET_NORMAL4,
-    /* 0x42 */ CAM_SET_SCENE0,
-    /* 0x43 */ CAM_SET_SPIRAL_DOOR,
-    /* 0x43 */ CAM_SET_MAX
+    /* 0x42 */ CAM_SET_LOOKUP,
+    /* 0x43 */ CAM_SET_TOWER0,
+    /* 0x44 */ CAM_SET_BRIDGE,
+    /* 0x45 */ CAM_SET_STAIRS,
+    /* 0x46 */ CAM_SET_TUNNEL,
+    /* 0x47 */ CAM_SET_SCENE0,
+    /* 0x48 */ CAM_SET_SPIRAL_DOOR,
+    /* 0x49 */ CAM_SET_DOORD,
+    /* 0x4A */ CAM_SET_MAX
 } CameraSettingType;
 
 typedef enum CameraModeType {

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -991,6 +991,26 @@ void Actor_SetObjectDependency(PlayState* play, Actor* actor) {
     gSegments[6] = OS_K0_TO_PHYSICAL(play->objectCtx.slots[actor->objectSlot].segment);
 }
 
+bool Actor_ExtendedDrawDistanceExempt(Actor* actor, PlayState* play) {
+    switch (actor->id) {
+        case ACTOR_DOOR_SHUTTER:
+        case ACTOR_EN_TORCH2:
+        case ACTOR_EN_BLKOBJ:
+        case ACTOR_EN_HORSE:
+        case ACTOR_EN_HORSE_GANON:
+        case ACTOR_EN_HORSE_ZELDA:
+            return true;
+
+        case ACTOR_EN_ZF:
+            if (play->sceneId == SCENE_DODONGOS_CAVERN)
+                return true;
+            return false;
+
+        default:
+            return false;
+    }
+}
+
 void Actor_Init(Actor* actor, PlayState* play) {
     Actor_SetWorldToHome(actor);
     Actor_SetShapeRotToWorld(actor);
@@ -1017,7 +1037,7 @@ void Actor_Init(Actor* actor, PlayState* play) {
         else actor->maxHealth = 0;
     }
 
-    if (EXTENDED_DRAW_DISTANCE && actor->id != ACTOR_EN_TORCH2 && actor->id != ACTOR_EN_BLKOBJ && actor->id != ACTOR_EN_HORSE && actor->id != ACTOR_EN_HORSE_GANON && actor->id != ACTOR_EN_HORSE_ZELDA && !(play->sceneId == SCENE_DODONGOS_CAVERN && actor->id == ACTOR_EN_ZF))
+    if (EXTENDED_DRAW_DISTANCE && !Actor_ExtendedDrawDistanceExempt(actor, play))
         actor->cullingVolumeDistance = actor->cullingVolumeScale = actor->cullingVolumeDownward = 32767.0f;
 }
 
@@ -4068,7 +4088,6 @@ void Actor_SetTextWithPrefix(PlayState* play, Actor* actor, s16 baseTextId) {
         case SCENE_KOKIRI_FOREST:
         case SCENE_SACRED_FOREST_MEADOW:
         case SCENE_LOST_WOODS:
-        case 112:
             prefix = 0x1000;
             break;
         case SCENE_STABLE:

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -8909,6 +8909,8 @@ s32 Camera_ChangeDoorCam(Camera* camera, Actor* doorActor, s16 bgCamIndex, f32 a
         PRINTF(".... change default door camera (set %d)\n", CAM_SET_DOORC);
     } else if (bgCamIndex == -2) {
         Camera_RequestSetting(camera, CAM_SET_SPIRAL_DOOR);
+    } else if (bgCamIndex == -3) {
+        Camera_RequestSetting(camera, CAM_SET_DOORD);
     } else {
         s32 setting = Camera_GetBgCamSetting(camera, bgCamIndex);
 

--- a/src/code/z_camera_data.inc.c
+++ b/src/code/z_camera_data.inc.c
@@ -187,8 +187,14 @@ char sCameraSettingNames[][12] = {
     "TEPPEN     ", // CAM_SET_DIRECTED_YAW
     "CIRCLE7    ", // CAM_SET_PIVOT_FROM_SIDE
     "NORMAL4    ", // CAM_SET_NORMAL4
+    "LOOKUP     ", // CAM_SET_LOOKUP
+    "TOWER0     ", // CAM_SET_TOWER0
+    "BRIDGE     ", // CAM_SET_BRIDGE
+    "STAIRS     ", // CAM_SET_STAIRS
+    "TUNNEL     ", // CAM_SET_TUNNEL
     "SCENE0     ", // CAM_SET_SCENE0
     "SPIRAL_DOOR", // CAM_SET_SPIRAL_DOOR
+    "DOORD      ", // CAM_SET_DOORD
 };
 
 char sCameraModeNames[][12] = {
@@ -1479,6 +1485,51 @@ CameraModeValue sSetNormal4ModeTalkData[] = {
 };
 
 /*=====================================================================
+ *                   Custom Data: LOOKUP Setting
+ *=====================================================================
+ */
+
+CameraModeValue sSetLookUpModeNormalData[] = {
+    /* CAM_FUNC_NORM1 */ { 10, 0 },  { 150, 1 }, { 250, 2 }, { -5, 3 }, { 10, 4 }, { 5, 5 }, { 30, 6 }, { 60, 7 }, { 60, 8 }, { 0x0003, 9 },
+};
+
+/*=====================================================================
+ *                   Custom Data: TOWER0 Setting
+ *=====================================================================
+ */
+
+CameraModeValue sSetTower0ModeNormalData[] = {
+    /* CAM_FUNC_NORM2 */ { 0, 0 }, { 270, 1 }, { 300, 2 }, { 82, 23 }, { 8, 4 }, { 60, 6 }, { 60, 7 }, { 100, 8 }, { 0x0000, 9 },
+};
+
+/*=====================================================================
+ *                   Custom Data: BRIDGE Setting
+ *=====================================================================
+ */
+
+CameraModeValue sSetBridgeModeNormalData[] = {
+    /* CAM_FUNC_NORM1 */ { -20, 0 }, { 250, 1 }, { 400, 2 }, { 10, 3 }, { 10, 4 }, { 10, 5 }, { 40, 6 }, { 60, 7 }, { 60, 8 }, { 0x0003, 9 },
+};
+
+/*=====================================================================
+ *                   Custom Data: STAIRS Setting
+ *=====================================================================
+ */
+
+CameraModeValue sSetStairsModeNormalData[] = {
+    /* CAM_FUNC_NORM1 */ { -10, 0 }, { 200, 1 }, { 300, 2 }, { 10, 3 }, { 12, 4 }, { 10, 5 }, { 35, 6 }, { 60, 7 }, { 60, 8 }, { 0x0003, 9 },
+};
+
+/*=====================================================================
+ *                   Custom Data: TUNNEL Setting
+ *=====================================================================
+ */
+
+CameraModeValue sSetTunnelModeNormalData[] = {
+    /* CAM_FUNC_NORM1 */ { -20, 0 }, { 150, 1 }, { 200, 2 }, { 0, 3 }, { 20, 4 }, { 10, 5 }, { 40, 6 }, { 60, 7 }, { 60, 8 }, { 0x0003, 9 },
+};
+
+/*=====================================================================
  *                   Custom Data: SCENE0 Setting
  *=====================================================================
  */
@@ -1491,6 +1542,20 @@ CameraModeValue sSetScene0ModeNormalData[] = { CAM_FUNCDATA_UNIQ2(-40, 20, 60, C
  */
 
 CameraModeValue sSetSpiralDoorModeNormalData[] = { CAM_FUNCDATA_SPEC8(-40, 50, 80, 60, 10, CAM_INTERFACE_FIELD(CAM_LETTERBOX_NONE, CAM_HUD_VISIBILITY_ALL, SPECIAL8_FLAG_0)) };
+
+/**
+ *=====================================================================
+ *                   Custom Data: DOORD Setting
+ *=====================================================================
+ */
+
+CameraModeValue sSetDoorDModeNormalData[] = {
+    /* CAM_FUNC_SPEC9 */ { -30, 0 }, { 60, 7 }, { 0x3002, 9 },
+};
+
+CameraModeValue sSetDoorDModeZParallelData[] = {
+    /* CAM_FUNC_SPEC9 */ { -30, 0 }, { 60, 7 }, { 0x300A, 9 },
+};
 
 /**
  * =====================================================================
@@ -2407,12 +2472,142 @@ CameraMode sCamSetNormal4Modes[] = {
     CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimDataMirror),        // CAM_MODE_Z_AIM_MIRROR
 };
 
+CameraMode sCamSetLookUpModes[] = {
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetLookUpModeNormalData),             // CAM_MODE_NORMAL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModeZParallelData),         // CAM_MODE_Z_PARALLEL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeZTargetFriendlyData),   // CAM_MODE_Z_TARGET_FRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP3, sSetNormal4ModeTalkData),              // CAM_MODE_TALK
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT1, sSetNormal1ModeZTargetUnfriendlyData), // CAM_MODE_Z_TARGET_UNFRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeWallClimbData),         // CAM_MODE_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeFirstPersonData),       // CAM_MODE_FIRST_PERSON
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimAdultData),          // CAM_MODE_AIM_ADULT
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimData),              // CAM_MODE_Z_AIM
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC5, sSetNormal0ModeHookshotFlyData),       // CAM_MODE_HOOKSHOT_FLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimBoomerangData),      // CAM_MODE_AIM_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimChildData),          // CAM_MODE_AIM_CHILD
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeZWallClimbData),        // CAM_MODE_Z_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_JUMP
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeLedgeHangData),         // CAM_MODE_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeZLedgeHangData),        // CAM_MODE_Z_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_FREE_FALL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT4, sSetNormal0ModeChargeData),            // CAM_MODE_CHARGE
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetNormal0ModeStillData),             // CAM_MODE_STILL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModePushPullData),          // CAM_MODE_PUSH_PULL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeFollowBoomerangData),   // CAM_MODE_FOLLOW_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimDataMirror),        // CAM_MODE_Z_AIM_MIRROR
+};
+
+CameraMode sCamSetTower0Modes[] = {
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM2, sSetTower0ModeNormalData),             // CAM_MODE_NORMAL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModeZParallelData),         // CAM_MODE_Z_PARALLEL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeZTargetFriendlyData),   // CAM_MODE_Z_TARGET_FRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP3, sSetNormal4ModeTalkData),              // CAM_MODE_TALK
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT1, sSetNormal1ModeZTargetUnfriendlyData), // CAM_MODE_Z_TARGET_UNFRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeWallClimbData),         // CAM_MODE_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeFirstPersonData),       // CAM_MODE_FIRST_PERSON
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimAdultData),          // CAM_MODE_AIM_ADULT
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimData),              // CAM_MODE_Z_AIM
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC5, sSetNormal0ModeHookshotFlyData),       // CAM_MODE_HOOKSHOT_FLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimBoomerangData),      // CAM_MODE_AIM_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimChildData),          // CAM_MODE_AIM_CHILD
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeZWallClimbData),        // CAM_MODE_Z_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_JUMP
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeLedgeHangData),         // CAM_MODE_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeZLedgeHangData),        // CAM_MODE_Z_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_FREE_FALL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT4, sSetNormal0ModeChargeData),            // CAM_MODE_CHARGE
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetNormal0ModeStillData),             // CAM_MODE_STILL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModePushPullData),          // CAM_MODE_PUSH_PULL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeFollowBoomerangData),   // CAM_MODE_FOLLOW_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimDataMirror),        // CAM_MODE_Z_AIM_MIRROR
+};
+
+CameraMode sCamSetBridgeModes[] = {
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetBridgeModeNormalData),             // CAM_MODE_NORMAL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModeZParallelData),         // CAM_MODE_Z_PARALLEL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeZTargetFriendlyData),   // CAM_MODE_Z_TARGET_FRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP3, sSetNormal4ModeTalkData),              // CAM_MODE_TALK
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT1, sSetNormal1ModeZTargetUnfriendlyData), // CAM_MODE_Z_TARGET_UNFRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeWallClimbData),         // CAM_MODE_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeFirstPersonData),       // CAM_MODE_FIRST_PERSON
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimAdultData),          // CAM_MODE_AIM_ADULT
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimData),              // CAM_MODE_Z_AIM
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC5, sSetNormal0ModeHookshotFlyData),       // CAM_MODE_HOOKSHOT_FLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimBoomerangData),      // CAM_MODE_AIM_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimChildData),          // CAM_MODE_AIM_CHILD
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeZWallClimbData),        // CAM_MODE_Z_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_JUMP
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeLedgeHangData),         // CAM_MODE_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeZLedgeHangData),        // CAM_MODE_Z_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_FREE_FALL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT4, sSetNormal0ModeChargeData),            // CAM_MODE_CHARGE
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetNormal0ModeStillData),             // CAM_MODE_STILL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModePushPullData),          // CAM_MODE_PUSH_PULL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeFollowBoomerangData),   // CAM_MODE_FOLLOW_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimDataMirror),        // CAM_MODE_Z_AIM_MIRROR
+};
+
+CameraMode sCamSetStairsModes[] = {
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetStairsModeNormalData),             // CAM_MODE_NORMAL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModeZParallelData),         // CAM_MODE_Z_PARALLEL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeZTargetFriendlyData),   // CAM_MODE_Z_TARGET_FRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP3, sSetNormal4ModeTalkData),              // CAM_MODE_TALK
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT1, sSetNormal1ModeZTargetUnfriendlyData), // CAM_MODE_Z_TARGET_UNFRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeWallClimbData),         // CAM_MODE_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeFirstPersonData),       // CAM_MODE_FIRST_PERSON
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimAdultData),          // CAM_MODE_AIM_ADULT
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimData),              // CAM_MODE_Z_AIM
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC5, sSetNormal0ModeHookshotFlyData),       // CAM_MODE_HOOKSHOT_FLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimBoomerangData),      // CAM_MODE_AIM_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimChildData),          // CAM_MODE_AIM_CHILD
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeZWallClimbData),        // CAM_MODE_Z_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_JUMP
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeLedgeHangData),         // CAM_MODE_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeZLedgeHangData),        // CAM_MODE_Z_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_FREE_FALL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT4, sSetNormal0ModeChargeData),            // CAM_MODE_CHARGE
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetNormal0ModeStillData),             // CAM_MODE_STILL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModePushPullData),          // CAM_MODE_PUSH_PULL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeFollowBoomerangData),   // CAM_MODE_FOLLOW_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimDataMirror),        // CAM_MODE_Z_AIM_MIRROR
+};
+
+CameraMode sCamSetTunnelModes[] = {
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetTunnelModeNormalData),             // CAM_MODE_NORMAL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModeZParallelData),         // CAM_MODE_Z_PARALLEL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeZTargetFriendlyData),   // CAM_MODE_Z_TARGET_FRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP3, sSetNormal4ModeTalkData),              // CAM_MODE_TALK
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT1, sSetNormal1ModeZTargetUnfriendlyData), // CAM_MODE_Z_TARGET_UNFRIENDLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeWallClimbData),         // CAM_MODE_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeFirstPersonData),       // CAM_MODE_FIRST_PERSON
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimAdultData),          // CAM_MODE_AIM_ADULT
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimData),              // CAM_MODE_Z_AIM
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC5, sSetNormal0ModeHookshotFlyData),       // CAM_MODE_HOOKSHOT_FLY
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimBoomerangData),      // CAM_MODE_AIM_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeAimChildData),          // CAM_MODE_AIM_CHILD
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP2, sSetNormal0ModeZWallClimbData),        // CAM_MODE_Z_WALL_CLIMB
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_JUMP
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeLedgeHangData),         // CAM_MODE_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ1, sSetNormal0ModeZLedgeHangData),        // CAM_MODE_Z_LEDGE_HANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_JUMP1, sSetNormal0ModeJumpData),              // CAM_MODE_FREE_FALL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_BATT4, sSetNormal0ModeChargeData),            // CAM_MODE_CHARGE
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_NORM1, sSetNormal0ModeStillData),             // CAM_MODE_STILL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_PARA1, sSetNormal0ModePushPullData),          // CAM_MODE_PUSH_PULL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_KEEP1, sSetNormal0ModeFollowBoomerangData),   // CAM_MODE_FOLLOW_BOOMERANG
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SUBJ3, sSetNormal0ModeZAimDataMirror),        // CAM_MODE_Z_AIM_MIRROR
+};
+
 CameraMode sCamSetScene0Modes[] = {
     CAM_SETTING_MODE_ENTRY(CAM_FUNC_UNIQ2, sSetScene0ModeNormalData), // CAM_MODE_NORMAL
 };
 
 CameraMode sCamSetSpiralDoorModes[] = {
     CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC8, sSetSpiralDoorModeNormalData), // CAM_MODE_NORMAL
+};
+
+CameraMode sCamSetDoorDModes[] = {
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC9, sSetDoorDModeNormalData),    // CAM_MODE_NORMAL
+    CAM_SETTING_MODE_ENTRY(CAM_FUNC_SPEC9, sSetDoorDModeZParallelData), // CAM_MODE_TARGET
 };
 
 CameraSetting sCameraSettings[] = {
@@ -2482,8 +2677,14 @@ CameraSetting sCameraSettings[] = {
     { { 0x053FFFFF }, sCamSetDirectedYawModes },          // CAM_SET_DIRECTED_YAW
     { { 0xC5000ECD }, sCamSetPivotFromSideModes },        // CAM_SET_PIVOT_FROM_SIDE
     { { 0x053FFFFF }, sCamSetNormal4Modes },              // CAM_SET_NORMAL4
+    { { 0x051FFFFF }, sCamSetLookUpModes },               // CAM_SET_LOOKUP
+    { { 0x851FFFFF }, sCamSetTower0Modes },               // CAM_SET_TOWER0
+    { { 0x051FFFFF }, sCamSetBridgeModes },               // CAM_SET_BRIDGE
+    { { 0x051FFFFF }, sCamSetStairsModes },               // CAM_SET_STAIRS
+    { { 0x051FFFFF }, sCamSetTunnelModes },               // CAM_SET_TUNNEL
     { { 0x00000001 }, sCamSetScene0Modes },               // CAM_SET_SCENE0
     { { 0x00000001 }, sCamSetSpiralDoorModes },           // CAM_SET_SPIRAL_DOOR
+    { { 0xC5000003 }, sCamSetDoorDModes },                // CAM_SET_DOORD
 };
 
 s32 Camera_Normal0(Camera* camera);


### PR DESCRIPTION
Fixes some issues with the Ancient Hollow
- Better documentation and formatting for actors and transition actors
- Chests use their X-rot value for content rewards now
- Red Rupees now use temporary scene flags
- Proper values for SurfaceTypes
- DOOR0 camtype restored for cam views
- Removed DOOR_SHUTTER from Extended Draw Distance to avoid crashing on RMG
- Use DOORD (restored Spaceworld camtype) camtype instead of DOORC camtype for default transitions
- Restored camtypes TOWER0, BRIDGE and STAIRS

Other fixes issues and inconsistencies
- Proper values for SurfaceTypes for Forbiden Woods
- Don't check for SceneId 112 to set NPC dialogue
- Restored camtypes LOOKUP and TUNNEL for Forbidden Woods and Goron Mines
- Fix chest clear flags for both Stalmaster grottos and the Armored Dinolfos grotto