### PR TITLE
v0.5.4 fixes (5 - Goron Mines)

### DIFF
--- a/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_0.c
+++ b/assets/scenes/dungeons/fairy_deku_tree/fairy_deku_tree_room_0.c
@@ -65,8 +65,8 @@ ActorEntry fairy_deku_tree_room_0ActorList0x000048[] = {
     { ACTOR_EN_GOOMBA,     {  -35,  400,  550 }, {    0,      0, 0 }, 0x0000 },
     { ACTOR_EN_GOOMBA,     {  400,  720, -370 }, {    0,      0, 0 }, 0x0000 },
     { ACTOR_EN_GOOMBA,     { -450, 1320,  300 }, {    0, 0x7530, 0 }, 0x0000 },
-    { ACTOR_OBJ_CRASHBOX,  {  825,    0,    0 }, {    0,      0, 0 }, 0x0012 },
-    { ACTOR_OBJ_CRASHBOX,  { 1020,    0, -155 }, {    0,  0xB00, 0 }, 0x0011 },
+    { ACTOR_OBJ_CRASHBOX,  {  825,    0,    0 }, {    0,      0, 0 }, 0xFF12 },
+    { ACTOR_OBJ_CRASHBOX,  { 1020,    0, -155 }, {    0,  0xB00, 0 }, 0xFF11 },
     { ACTOR_ELF_MSG,       {    0,    0, -750 }, {    0,      0, 0 }, 0x0911 },
 };
 

--- a/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_0.c
+++ b/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_0.c
@@ -13,7 +13,7 @@ SceneCmd old_dodongos_cavern_room_0[] = {
     SCENE_CMD_SKYBOX_DISABLES(true /* no skybox */, true /* no sun/moon */),
     SCENE_CMD_TIME_SETTINGS(/* don't set time */ 0xFF, 0xFF, 0 /* time doesn't move */),
     SCENE_CMD_ROOM_SHAPE(&old_dodongos_cavern_room_0MeshHeader0x0001A0),
-    SCENE_CMD_OBJECT_LIST(15, old_dodongos_cavern_room_0ObjectList0x000038),
+    SCENE_CMD_OBJECT_LIST(14, old_dodongos_cavern_room_0ObjectList0x000038),
     SCENE_CMD_ACTOR_LIST(23, old_dodongos_cavern_room_0ActorList0x000044),
     SCENE_CMD_END(),
 };
@@ -37,7 +37,6 @@ s16 old_dodongos_cavern_room_0ObjectList0x000038[] = {
     OBJECT_GOROIWA,
     OBJECT_CRASHBOX,
     OBJECT_SYOKUDAI,
-    OBJECT_DEMO_KEKKAI,
     OBJECT_KIBAKO2,
     OBJECT_FR,
 };
@@ -62,7 +61,7 @@ ActorEntry old_dodongos_cavern_room_0ActorList0x000044[] = {
     { ACTOR_OBJ_SWITCH,       {  900,    0, -1520 }, {      0,      0,      0 }, 0x0101 }, // Switch: 01
     { ACTOR_OBJ_SWITCH,       {  900,   80, -2120 }, {      0,      0,      0 }, 0x1001 }, // Switch: 10
     { ACTOR_BG_ICE_SHELTER,   {  900,   80, -2120 }, {      0,      0,      0 }, 0x0508 }, // Switch: 08
-    { ACTOR_BG_GND_DARKMEIRO, {  800,  120, -2120 }, { 0x4000,      0, 0x4000 }, 0x1003 }, // Clears on switch: 10
+    { ACTOR_OBJ_CRASHBOX,     {  815,   80, -2120 }, {      0,      0,      0 }, 0x0313 }, // Switch: 03
     { ACTOR_BG_ICE_SHELTER,   {    0,  240, -2680 }, {      0,      0,      0 }, 0x050A }, // Switch: 0A
     { ACTOR_BG_WOOD_PILLAR,   {    0,  240, -2680 }, {      0,      0,      0 }, 0x0000 },
     { ACTOR_OBJ_KIBAKO3,      { -776,  360, -2930 }, {      0, 0x4000,      0 }, 0x0233 }, // Red: 3 (Goron Mines)

--- a/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_2.c
+++ b/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_2.c
@@ -37,9 +37,9 @@ s16 old_dodongos_cavern_room_2ObjectList0x000038[] = {
     OBJECT_GOROIWA,
     OBJECT_CRASHBOX,
     OBJECT_GI_HEART,
-    OBJECT_BOMBF,
     OBJECT_KIBAKO2,
     OBJECT_FR,
+    OBJECT_BOMBF,
 };
 
 ActorEntry old_dodongos_cavern_room_2ActorList0x000048[] = {

--- a/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_4.c
+++ b/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_4.c
@@ -13,7 +13,7 @@ SceneCmd old_dodongos_cavern_room_4[] = {
     SCENE_CMD_SKYBOX_DISABLES(true /* no skybox */, true /* no sun/moon */),
     SCENE_CMD_TIME_SETTINGS(/* don't set time */ 0xFF, 0xFF, 0 /* time doesn't move */),
     SCENE_CMD_ROOM_SHAPE(&old_dodongos_cavern_room_4MeshHeader0x0000B0),
-    SCENE_CMD_OBJECT_LIST(14, old_dodongos_cavern_room_4ObjectList0x000038),
+    SCENE_CMD_OBJECT_LIST(13, old_dodongos_cavern_room_4ObjectList0x000038),
     SCENE_CMD_ACTOR_LIST(10, old_dodongos_cavern_room_4ActorList0x000048),
     SCENE_CMD_END(),
 };
@@ -37,7 +37,6 @@ s16 old_dodongos_cavern_room_4ObjectList0x000038[] = {
     OBJECT_GOROIWA,
     OBJECT_CRASHBOX,
     OBJECT_SYOKUDAI,
-    OBJECT_DEMO_KEKKAI,
     OBJECT_KBT,
 };
 

--- a/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_6.c
+++ b/assets/scenes/dungeons/old_dodongos_cavern/old_dodongos_cavern_room_6.c
@@ -43,7 +43,7 @@ ActorEntry old_dodongos_cavern_room_6ActorList0x000048[] = {
     { ACTOR_OBJECT_KANKYO,      {    0,    0,     0 }, { 0,      0, 0 }, 0x0006 },
     { ACTOR_EN_BEAST,           { 1962,  531, -2097 }, { 0, 0xC000, 0 }, 0x7F00 },
     { ACTOR_EN_BEAST,           { 2219,  531, -1300 }, { 0, 0xA000, 0 }, 0x7F00 },
-    { ACTOR_OBJ_CRASHBOX,       { 1960,  531, -1180 }, { 0,      0, 0 }, 0x0002 },
+    { ACTOR_OBJ_CRASHBOX,       { 1960,  531, -1180 }, { 0,      0, 0 }, 0xFF02 },
     { ACTOR_OBJ_OSHIHIKI,       { 1960,  531, -1180 }, { 0,      0, 0 }, 0xFF00 },
     { ACTOR_OBJ_FLOATER,        { 2300,  549, -1520 }, { 0,      0, 0 }, 0x9700 },
     { ACTOR_BG_DBLUE_WATERFALL, { 2300, 1171, -1520 }, { 0,      0, 0 }, 0x200D }, // Switch: 0D

--- a/src/overlays/actors/ovl_Obj_Crashbox/z_obj_crashbox.c
+++ b/src/overlays/actors/ovl_Obj_Crashbox/z_obj_crashbox.c
@@ -67,11 +67,20 @@ static InitChainEntry sInitChain[] = {
     ICHAIN_F32(cullingVolumeDownward, 1000, ICHAIN_STOP),
 };
 
-static f32 sObjCrashboxSize[] = { 0.5f, 0.75f, 1.0f };
+static Vec3f sObjCrashboxSize[] = {
+    { 0.5f  , 0.5f,   0.5f },
+    { 0.75f, 0.75f,  0.75f },
+    { 1.0f,   1.0f,   1.0f },
+    { 0.25f,  0.5f, 1.325f },
+};
 
 void ObjCrashbox_Init(Actor* thisx, PlayState* play) {
     ObjCrashbox* this = (ObjCrashbox*)thisx;
     CollisionHeader* colHeader = NULL;
+
+    this->switchFlag = (thisx->params >> 8) & 0xFF;
+    if (this->switchFlag <= 0x3F && Flags_GetSwitch(play, this->switchFlag))
+        Actor_Kill(&this->dyna.actor);
 
     this->timer = 5;
 
@@ -89,7 +98,7 @@ void ObjCrashbox_Init(Actor* thisx, PlayState* play) {
     this->actionFunc = ObjCrashbox_Wait;
 
     this->type = (this->dyna.actor.params >> 4) & 1;
-    Actor_SetScale(&this->dyna.actor, sObjCrashboxSize[this->dyna.actor.params & 3]);
+    thisx->scale = sObjCrashboxSize[this->dyna.actor.params & 3];
 }
 
 void ObjCrashbox_Destroy(Actor* thisx, PlayState* play) {
@@ -113,6 +122,9 @@ void ObjCrashbox_Break(ObjCrashbox* this, PlayState* play) {
     f32 cos = Math_CosS(thisx->shape.rot.y);
     f32 tmp1, tmp2;
     f32 scale;
+
+    if (this->switchFlag <= 0x3F)
+        Flags_SetSwitch(play, this->switchFlag);
 
     for (i=0; i<5; i++) {
         pos.y = (24 * i) + thisx->world.pos.y;

--- a/src/overlays/actors/ovl_Obj_Crashbox/z_obj_crashbox.h
+++ b/src/overlays/actors/ovl_Obj_Crashbox/z_obj_crashbox.h
@@ -19,6 +19,7 @@ typedef struct ObjCrashbox {
     /* 0x0170 */ ColliderCylinder collider;
     /* 0x01BC */ u8 timer;
     /* 0x01BD */ u8 type;
+    /* 0x01BE */ u8 switchFlag;
 } ObjCrashbox; // size = 0x01C0
 
 #endif


### PR DESCRIPTION
Another fixes PR.

An attempt to fix the Goron Mines by removing the Ganon's Castle object, and replacing the Clear Block with a Crashbox (crashboxes have been adjusted with switch flags and a new type). The Ganon's Castle object might simply have been too much on the RAM. Dunno if it fixes the crashes with the Goron Mines but it's worth changing anyway, since the Ganon's Castle object is massive.